### PR TITLE
Phase 0 completion + fix diagonal checkmate detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       # Uses the ruff version pinned in uv.lock for reproducibility.
       - name: Ruff lint
         run: uv run ruff check
-      # `ruff format --check` will be added once the codebase is formatted
-      # (the next Phase 0 checklist item).
+      - name: Ruff format
+        run: uv run ruff format --check
       - name: mypy (lenient)
         run: uv run mypy
 
@@ -51,3 +51,15 @@ jobs:
       # and exercise the api-endpoint + remote client (api/client extras).
       - name: Integration tests
         run: uv run --extra api --extra client pytest tests/integration
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      # Runs the whole suite (unit + integration) so the coverage number is
+      # authoritative, and fails the build if it drops below the gate.
+      - name: Tests with coverage gate
+        run: uv run --extra api --extra client pytest --cov --cov-report=term-missing --cov-fail-under=75

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ __pycache__/
 build/
 dist/
 
+# test & coverage artifacts
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.ruff_cache/
+.mypy_cache/
+
 # IDE
 .idea/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     # Keep in sync with the ruff version pinned in uv.lock.
     rev: v0.15.20
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Run `pre-commit install` once to enable these hooks locally.
+# They mirror the CI `lint` job: ruff lint (with autofix) + ruff format.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with the ruff version pinned in uv.lock.
+    rev: v0.15.20
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,17 +4,17 @@ from chesssnake import Game
 game = Game(white_name="Bob", black_name="Phil")
 
 # Make moves
-game.move('e4') # Bob's move
-game.move('e5') # Phil's move
+game.move("e4")  # Bob's move
+game.move("e5")  # Phil's move
 
 # Print the board
 print(game)
 
 # make the move, and show the board in png format
-game.move('Nc3', img=True).show()
+game.move("Nc3", img=True).show()
 
 # save the board as a png
-game.save('/path/to/your/image1.png')
+game.save("/path/to/your/image1.png")
 
 # make the move, and save the board as a png
-game.move('Bc5', save='/path/to/your/image2.png')
+game.move("Bc5", save="/path/to/your/image2.png")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,21 @@ dev = [
     "httpx>=0.27",
     "ruff>=0.9",
     "mypy>=1.8",
+    "pytest-cov>=5.0",
+    "pre-commit>=3.5",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: tests that need the DB/API stack (deselect with -m 'not integration')",
+]
+
+[tool.coverage.run]
+source = ["chesssnake"]
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ruff]
 line-length = 120

--- a/src/chesssnake/__init__.py
+++ b/src/chesssnake/__init__.py
@@ -1,3 +1,3 @@
 from .remote.game import Game
 
-__all__ = ['Game']
+__all__ = ["Game"]

--- a/src/chesssnake/api/server.py
+++ b/src/chesssnake/api/server.py
@@ -37,6 +37,7 @@ app = FastAPI(title="chesssnake api-endpoint", lifespan=lifespan)
 
 # --- Schemas ---------------------------------------------------------------
 
+
 class GameCreate(BaseModel):
     group_id: int = 0
     white_id: int = 0
@@ -84,6 +85,7 @@ def _state(row):
 # --- Exception handlers ----------------------------------------------------
 # Map domain errors to structured JSON so the client can re-raise the same types.
 
+
 def _error(status_code, exc):
     return JSONResponse(
         status_code=status_code,
@@ -113,6 +115,7 @@ async def _handle_game_error(_request, exc):
 
 # --- Routes ----------------------------------------------------------------
 
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}
@@ -120,18 +123,24 @@ async def health():
 
 @app.post("/games")
 async def create_game(body: GameCreate):
-    row = ops.game_get_or_create(
-        body.group_id, body.white_id, body.black_id, body.white_name, body.black_name
-    )
+    row = ops.game_get_or_create(body.group_id, body.white_id, body.black_id, body.white_name, body.black_name)
     return _state(row)
 
 
 @app.put("/games/{group_id}/{white_id}/{black_id}")
 async def update_game(group_id: int, white_id: int, black_id: int, state: GameState):
     ops.game_update(
-        group_id, white_id, black_id,
-        state.board, state.turn, state.pawnmove, state.draw,
-        state.moved, state.status, state.wname, state.bname,
+        group_id,
+        white_id,
+        black_id,
+        state.board,
+        state.turn,
+        state.pawnmove,
+        state.draw,
+        state.moved,
+        state.status,
+        state.wname,
+        state.bname,
     )
     return {"status": "ok"}
 

--- a/src/chesssnake/cli.py
+++ b/src/chesssnake/cli.py
@@ -20,15 +20,13 @@ def _run_api_endpoint(args):
     try:
         import uvicorn
     except ImportError:
-        sys.exit(
-            "The api-endpoint requires FastAPI and uvicorn. "
-            "Install them with: pip install chesssnake[api]"
-        )
+        sys.exit("The api-endpoint requires FastAPI and uvicorn. Install them with: pip install chesssnake[api]")
     uvicorn.run("chesssnake.api.server:app", host=args.host, port=args.port)
 
 
 def _run_init_db(_args):
     from .db.sql import initialize_connection_pool, psql_db_schema_init
+
     initialize_connection_pool()
     psql_db_schema_init()
 

--- a/src/chesssnake/db/errors.py
+++ b/src/chesssnake/db/errors.py
@@ -2,37 +2,45 @@ class GameError(Exception):
     def __init__(self, msg):
         super().__init__(msg)
 
+
 class SQLError(GameError):
     def __init__(self, msg):
         super().__init__(msg)
 
+
 class SQLIdError(SQLError):
     def __init__(self, id_):
-        msg = "\n".join([
-            "One of the given ids is invalid for a PostgreSQL database:",
-            f"  id: {id_}",
-            "All IDs must be BIGINT NOT NULL."
-        ])
+        msg = "\n".join(
+            [
+                "One of the given ids is invalid for a PostgreSQL database:",
+                f"  id: {id_}",
+                "All IDs must be BIGINT NOT NULL.",
+            ]
+        )
         super().__init__(msg)
+
 
 class SQLAuthError(SQLError):
     def __init__(self):
-        msg = "\n".join([
-            "The SQL database credentials are invalid.",
-            "There are four ways to set the database credentials:"
-            "Option 1: Set the CHESSDB_CONN_STR environment variable to a valid connection string:"
-            "  CHESSDB_CONN_STR='postgresql://user:password@localhost:5432/name'",
-            "Option 2: Make sure these environment variables are set:",
-            "  CHESSDB_NAME, CHESSDB_USER, CHESSDB_PASS",
-            "  It is also recommended that you also set CHESSDB_HOST and CHESSDB_PORT",
-            "Option 3: Set the database connection string when declaring a Game object:",
-            "  creds = {'conn_str':'postgresql://user:password@localhost:5432/name'}",
-            "  db_init(sql_creds=creds)",
-            "Option 4, set the database connection credentials when declaring a Game object. For example:",
-            "  creds = {'name':'name', 'user':'user', 'pass':'password'}",
-            "  db_init(sql_creds=creds)",
-        ])
+        msg = "\n".join(
+            [
+                "The SQL database credentials are invalid.",
+                "There are four ways to set the database credentials:"
+                "Option 1: Set the CHESSDB_CONN_STR environment variable to a valid connection string:"
+                "  CHESSDB_CONN_STR='postgresql://user:password@localhost:5432/name'",
+                "Option 2: Make sure these environment variables are set:",
+                "  CHESSDB_NAME, CHESSDB_USER, CHESSDB_PASS",
+                "  It is also recommended that you also set CHESSDB_HOST and CHESSDB_PORT",
+                "Option 3: Set the database connection string when declaring a Game object:",
+                "  creds = {'conn_str':'postgresql://user:password@localhost:5432/name'}",
+                "  db_init(sql_creds=creds)",
+                "Option 4, set the database connection credentials when declaring a Game object. For example:",
+                "  creds = {'name':'name', 'user':'user', 'pass':'password'}",
+                "  db_init(sql_creds=creds)",
+            ]
+        )
         super().__init__(msg)
+
 
 class ChallengeError(GameError):
     def __init__(self, msg):

--- a/src/chesssnake/db/postgres.py
+++ b/src/chesssnake/db/postgres.py
@@ -41,6 +41,7 @@ def db_init(sql_creds=None, create_database=False):
 
 # --- Games -----------------------------------------------------------------
 
+
 def game_get_or_create(group_id, white_id, black_id, white_name="", black_name=""):
     """
     Loads the game for ``(group_id, white_id, black_id)``, creating a fresh one if
@@ -94,9 +95,17 @@ def game_update(group_id, white_id, black_id, board, turn, pawnmove, draw, moved
         WHERE GroupId = %(group_id)s AND WhiteId = %(white_id)s AND BlackId = %(black_id)s
     """
     params = {
-        "board": board, "turn": turn, "pawnmove": pawnmove, "draw": draw,
-        "moved": moved, "status": status, "wname": wname, "bname": bname,
-        "group_id": group_id, "white_id": white_id, "black_id": black_id,
+        "board": board,
+        "turn": turn,
+        "pawnmove": pawnmove,
+        "draw": draw,
+        "moved": moved,
+        "status": status,
+        "wname": wname,
+        "bname": bname,
+        "group_id": group_id,
+        "white_id": white_id,
+        "black_id": black_id,
     }
     execute_psql(query, params=params)
 
@@ -180,6 +189,7 @@ def game_exists(player1, player2, group_id=0):
 
 # --- Challenges ------------------------------------------------------------
 
+
 def challenge_exists(player1, player2, group_id=0):
     """Returns ``{"challenger", "challenged"}`` for a pending challenge, or ``None``."""
     validate_ids(player1, player2, group_id)
@@ -236,18 +246,14 @@ def challenge(challenger, opponent, group_id=0):
         raise errors.ChallengeError("You can't challenge yourself.")
 
     if game_exists(challenger, opponent, group_id):
-        raise errors.ChallengeError(
-            f"There is an unresolved game between {challenger} and {opponent} already!"
-        )
+        raise errors.ChallengeError(f"There is an unresolved game between {challenger} and {opponent} already!")
 
     existing = challenge_exists(challenger, opponent, group_id)
     if existing is None:
         challenge_create(challenger, opponent, group_id)
         return False
     elif challenger == existing["challenger"]:
-        raise errors.ChallengeError(
-            f"You have already challenged {opponent}! Wait for them to accept."
-        )
+        raise errors.ChallengeError(f"You have already challenged {opponent}! Wait for them to accept.")
 
     # A reciprocal challenge exists: accept it by deleting the stored challenge.
     challenge_delete(existing["challenger"], existing["challenged"], group_id)

--- a/src/chesssnake/db/sql.py
+++ b/src/chesssnake/db/sql.py
@@ -22,7 +22,7 @@ def load_env_psql_creds():
         "user": getenv("CHESSDB_USER"),
         "password": getenv("CHESSDB_PASS"),
         "host": getenv("CHESSDB_HOST", "localhost"),
-        "port": getenv("CHESSDB_PORT", "5432")
+        "port": getenv("CHESSDB_PORT", "5432"),
     }
 
 
@@ -57,9 +57,7 @@ def initialize_connection_pool(minconn=1, maxconn=10, sql_creds=None):
     global connection_pool
     try:
         connection_pool = pool.SimpleConnectionPool(
-            minconn=minconn,
-            maxconn=maxconn,
-            dsn=load_psql_conn_str(sql_creds=sql_creds)
+            minconn=minconn, maxconn=maxconn, dsn=load_psql_conn_str(sql_creds=sql_creds)
         )
         if connection_pool:
             print("Database connection pool successfully initialized.")
@@ -73,8 +71,9 @@ def get_connection():
     :return: A connection object from the pool.
     """
     if not connection_pool:
-        raise errors.SQLError("Connection pool is not initialized.\n"
-                                 "    Use chesssnake.db.sql.initialize_connection_pool")
+        raise errors.SQLError(
+            "Connection pool is not initialized.\n    Use chesssnake.db.sql.initialize_connection_pool"
+        )
     return connection_pool.getconn()
 
 
@@ -161,7 +160,7 @@ def psql_db_schema_init(sql_creds=None):
     try:
         # Establish a direct connection using environment-based or provided credentials
         conn = psycopg2.connect(load_psql_conn_str(sql_creds=sql_creds))
-        db_init_fp = asset_path('init.sql')
+        db_init_fp = asset_path("init.sql")
         with open(db_init_fp) as db_init_file:
             init_script = db_init_file.read()
 
@@ -176,12 +175,14 @@ def psql_db_schema_init(sql_creds=None):
         raise errors.SQLError(
             f"{e}\n"
             f"Database initialization file not found, likely due to corrupt or modified installation.\n"
-            f"Try reinstalling chesssnake.")
+            f"Try reinstalling chesssnake."
+        )
     except psycopg2.Error as e:
         raise errors.SQLError(f"Database initialization error:\n{e}")
     finally:
         if conn:
             conn.close()
+
 
 def validate_ids(*ids: int):
     """
@@ -199,6 +200,7 @@ def validate_ids(*ids: int):
             raise errors.SQLIdError(id_)
         if not (BIGINT_MIN <= id_ <= BIGINT_MAX):
             raise errors.SQLIdError(id_)
+
 
 def execute_psql(statement, params=None):
     """

--- a/src/chesssnake/engine/board.py
+++ b/src/chesssnake/engine/board.py
@@ -30,6 +30,7 @@ class Board:
         - 2: Stalemate has occurred, and the game is over.
     :type status: int
     """
+
     def __init__(self, board=None, two_moveP=None):
         """
         Initializes the chessboard.
@@ -45,34 +46,30 @@ class Board:
         :type two_moveP: Square or None
         """
         if board is None:
-
             # creates board
             board = []
 
             # sets up back rank template with same index as j
-            backrank = ['R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R']
+            backrank = ["R", "N", "B", "Q", "K", "B", "N", "R"]
 
             # vertical
             for i in range(8):
-
                 # adds new rank
                 board.append([])
 
                 # horizontal
                 for j in range(8):
-
                     # black backrank
                     if i == 0:
-
-                        if backrank[j] == 'R':
+                        if backrank[j] == "R":
                             piece = Rook(1)
-                        elif backrank[j] == 'N':
+                        elif backrank[j] == "N":
                             piece = Knight(1)
-                        elif backrank[j] == 'B':
+                        elif backrank[j] == "B":
                             piece = Bishop(1)
-                        elif backrank[j] == 'Q':
+                        elif backrank[j] == "Q":
                             piece = Queen(1)
-                        elif backrank[j] == 'K':
+                        elif backrank[j] == "K":
                             piece = King(1)
                         else:
                             piece = None
@@ -89,16 +86,15 @@ class Board:
 
                     # white backrank
                     elif i == 7:
-
-                        if backrank[j] == 'R':
+                        if backrank[j] == "R":
                             piece = Rook(0)
-                        elif backrank[j] == 'N':
+                        elif backrank[j] == "N":
                             piece = Knight(0)
-                        elif backrank[j] == 'B':
+                        elif backrank[j] == "B":
                             piece = Bishop(0)
-                        elif backrank[j] == 'Q':
+                        elif backrank[j] == "Q":
                             piece = Queen(0)
-                        elif backrank[j] == 'K':
+                        elif backrank[j] == "K":
                             piece = King(0)
                         else:
                             piece = None
@@ -170,7 +166,7 @@ class Board:
         out = ""
 
         for i in range(0, 8):
-            out += str(8-i) + "\t"
+            out += str(8 - i) + "\t"
             for j in range(0, 8):
                 if self[i, j].piece is not None:
                     out += self[i, j].piece.piecetype.value
@@ -220,21 +216,21 @@ class Board:
         # moving the rook for castling
         if m.castle is not None:
             x = 7 if player == Color.WHITE else 0
-            j1 = 7 if m.castle == 'K' else 0
-            j2 = 5 if m.castle == 'K' else 3
+            j1 = 7 if m.castle == "K" else 0
+            j2 = 5 if m.castle == "K" else 3
             self[x, j1].piece = None
             self[x, j2].piece = Rook(player, moved=True)
 
         # pawn promotions
         new_piece = m.piece
         if m.promotion is not None:
-            if m.promotion == 'Q':
+            if m.promotion == "Q":
                 new_piece = Queen(player)
-            elif m.promotion == 'R':
+            elif m.promotion == "R":
                 new_piece = Rook(player)
-            elif m.promotion == 'B':
+            elif m.promotion == "B":
                 new_piece = Bishop(player)
-            elif m.promotion == 'N':
+            elif m.promotion == "N":
                 new_piece = Knight(player)
 
         # sets the board correctly
@@ -290,8 +286,8 @@ class Board:
         # moving the rook for castling
         if move.castle is not None:
             x = 7 if player == Color.WHITE else 0
-            j1 = 7 if move.castle == 'K' else 0
-            j2 = 5 if move.castle == 'K' else 3
+            j1 = 7 if move.castle == "K" else 0
+            j2 = 5 if move.castle == "K" else 3
             self[x, j1].piece = Rook(player, moved=False)
             self[x, j2].piece = None
 
@@ -314,18 +310,16 @@ class Board:
         """
         color = Color(color)
         for x in range(8):
-
             # if color is white, search from bottom up
             # if color is black, search from top down
             i = 7 - x if color == Color.WHITE else x
 
             # search from right to left (it is common to kingside castle, which is towards the right)
             for j in range(7, -1, -1):
-
                 if (
-                        self[i, j].piece is not None
-                        and self[i, j].piece.piecetype == PieceType.KING
-                        and self[i, j].piece.color == color
+                    self[i, j].piece is not None
+                    and self[i, j].piece.piecetype == PieceType.KING
+                    and self[i, j].piece.color == color
                 ):
                     return self[i, j]
 
@@ -430,20 +424,18 @@ class Board:
         delta_js = [0, 1, 1, 1, 0, -1, -1, -1]
         with self.lifted(king_square):
             for index in range(8):
-
                 psquare = self[king_square.i + delta_is[index], king_square.j + delta_js[index]]
 
                 # if there is a square that the king can move to, returns false
                 if (
-                        psquare is not None
-                        and (psquare.piece is None or psquare.piece.color == player.opponent)
-                        and len(self.threats_on(psquare, player)) == 0
+                    psquare is not None
+                    and (psquare.piece is None or psquare.piece.color == player.opponent)
+                    and len(self.threats_on(psquare, player)) == 0
                 ):
                     return False
 
         # checks if the piece threatening can be taken OR if the piece threatening can be blocked
         if len(threats) == 1:  # this will only work if there is only one threatening piece
-
             # this is the only threat, now saved to threat
             threat = threats[0]
 
@@ -459,7 +451,6 @@ class Board:
 
                 # if any of the possible blocking squares (pbsquares) are blockable, returns false
                 for pbsquare in pbsquares:
-
                     # a friendly pawn can block the threat by advancing (a non-capture move)
                     if Pawn.find_all(self, pbsquare, player, capture=False):
                         return False
@@ -468,7 +459,6 @@ class Board:
                     # possible blocking threats (pbthreats)
                     pbthreats = self.threats_on(pbsquare, player.opponent)
                     if len(pbthreats) != 0:
-
                         # kings and pawns need to be excluded from this list:
                         #   - kings can't block a check
                         #   - pawns can't block a check by capturing
@@ -539,14 +529,13 @@ class Board:
         for i in range(8):
             board.append([])
             for j in range(8):
-
                 # creates the piece
                 if boardstringarray[i][j][0] == "R":
                     if (
-                        (i == 7 and j == 0 and moved[0] == '1') or
-                        (i == 7 and j == 7 and moved[2] == '1') or
-                        (i == 0 and j == 0 and moved[0] == '1') or
-                        (i == 0 and j == 7 and moved[2] == '1')
+                        (i == 7 and j == 0 and moved[0] == "1")
+                        or (i == 7 and j == 7 and moved[2] == "1")
+                        or (i == 0 and j == 0 and moved[0] == "1")
+                        or (i == 0 and j == 7 and moved[2] == "1")
                     ):
                         piece = Rook(boardstringarray[i][j][1], True)
                     else:
@@ -558,10 +547,7 @@ class Board:
                 elif boardstringarray[i][j][0] == "Q":
                     piece = Queen(boardstringarray[i][j][1])
                 elif boardstringarray[i][j][0] == "K":
-                    if (
-                        (i == 7 and j == 4 and moved[1] == '1') or
-                        (i == 0 and j == 4 and moved[1] == '1')
-                    ):
+                    if (i == 7 and j == 4 and moved[1] == "1") or (i == 0 and j == 4 and moved[1] == "1"):
                         piece = King(boardstringarray[i][j][1], True)
                     else:
                         piece = King(boardstringarray[i][j][1], False)
@@ -604,23 +590,47 @@ class Board:
         :rtype: tuple[str, str]
         """
         boardstring = ""
-        moved = ['0', '0', '0', '0', '0', '0']
+        moved = ["0", "0", "0", "0", "0", "0"]
         for rank in board:
             for square in rank:
                 if square.piece is not None:
                     boardstring += square.piece.piecetype.value + str(int(square.piece.color)) + " "
 
-                    if (square.i == 7 and square.j == 0) and square.piece.piecetype == PieceType.ROOK and square.piece.moved:
+                    if (
+                        (square.i == 7 and square.j == 0)
+                        and square.piece.piecetype == PieceType.ROOK
+                        and square.piece.moved
+                    ):
                         moved[0] = "1"
-                    elif (square.i == 7 and square.j == 4) and square.piece.piecetype == PieceType.KING and square.piece.moved:
+                    elif (
+                        (square.i == 7 and square.j == 4)
+                        and square.piece.piecetype == PieceType.KING
+                        and square.piece.moved
+                    ):
                         moved[1] = "1"
-                    elif (square.i == 7 and square.j == 7) and square.piece.piecetype == PieceType.ROOK and square.piece.moved:
+                    elif (
+                        (square.i == 7 and square.j == 7)
+                        and square.piece.piecetype == PieceType.ROOK
+                        and square.piece.moved
+                    ):
                         moved[2] = "1"
-                    elif (square.i == 0 and square.j == 0) and square.piece.piecetype == PieceType.ROOK and square.piece.moved:
+                    elif (
+                        (square.i == 0 and square.j == 0)
+                        and square.piece.piecetype == PieceType.ROOK
+                        and square.piece.moved
+                    ):
                         moved[3] = "1"
-                    elif (square.i == 0 and square.j == 4) and square.piece.piecetype == PieceType.KING and square.piece.moved:
+                    elif (
+                        (square.i == 0 and square.j == 4)
+                        and square.piece.piecetype == PieceType.KING
+                        and square.piece.moved
+                    ):
                         moved[4] = "1"
-                    elif (square.i == 0 and square.j == 7) and square.piece.piecetype == PieceType.ROOK and square.piece.moved:
+                    elif (
+                        (square.i == 0 and square.j == 7)
+                        and square.piece.piecetype == PieceType.ROOK
+                        and square.piece.moved
+                    ):
                         moved[5] = "1"
 
                 else:

--- a/src/chesssnake/engine/board.py
+++ b/src/chesssnake/engine/board.py
@@ -375,6 +375,28 @@ class Board:
 
         return len(self.threats_on(king_square, player)) > 0
 
+    def _squares_between(self, a, b):
+        """
+        Squares strictly between two colinear squares ``a`` and ``b`` (exclusive).
+
+        Works for a shared rank, file, or diagonal — the only lines along which a
+        sliding piece can check a king. Returns an empty list when the squares are
+        adjacent (nothing can be interposed).
+
+        :param a: One endpoint square (e.g. the king's square).
+        :type a: Square
+        :param b: The other endpoint square (e.g. the checking piece's square).
+        :type b: Square
+        :return: The list of `Square` objects strictly between ``a`` and ``b``.
+        :rtype: list[Square]
+        """
+        di = b.i - a.i
+        dj = b.j - a.j
+        steps = max(abs(di), abs(dj))
+        step_i = (di > 0) - (di < 0)  # sign of di (-1, 0, or 1)
+        step_j = (dj > 0) - (dj < 0)  # sign of dj (-1, 0, or 1)
+        return [self[a.i + s * step_i, a.j + s * step_j] for s in range(1, steps)]
+
     # returns true if the given player is in checkmate
     # returns false otherwise
     def check_for_mate(self, player):
@@ -431,64 +453,9 @@ class Board:
 
             # blocking
             if threat.piece.piecetype in (PieceType.ROOK, PieceType.BISHOP, PieceType.QUEEN):
-                pbsquares = []
-                # horizontal and vertical
-                if threat.piece.piecetype in (PieceType.ROOK, PieceType.QUEEN):
-
-                    # if they are on the same rank...
-                    if threat.i == king_square.i:
-                        if threat.j > king_square.j:
-                            upper = threat.j
-                            lower = king_square.j
-                        else:
-                            upper = king_square.j
-                            lower = threat.j
-
-                        # loops through all squares between the threatening piece and the king
-                        for x in range(lower + 1, upper):
-                            pbsquares.append(self[threat.i, x])
-
-                    # if they are on the same file...
-                    elif threat.j == king_square.j:
-                        if threat.i > king_square.i:
-                            upper = threat.i
-                            lower = king_square.i
-                        else:
-                            upper = king_square.i
-                            lower = threat.i
-
-                        # loops through all squares between the threatening piece and the king
-                        for x in range(lower + 1, upper):
-                            pbsquares.append(self[x, threat.j])
-
-                # diagonal
-                if threat.piece.piecetype in (PieceType.BISHOP, PieceType.QUEEN):
-
-                    delta_i = threat.i - king_square.j
-                    delta_j = threat.j - king_square.j
-
-                    # this is the number of squares diagonally inbetween the threat and the king
-                    num_between = abs(delta_i) - 1
-
-                    # threat is positive i positive j compared to king
-                    if delta_i > 0 < delta_j:
-                        for x in range(num_between):
-                            pbsquares.append(self[threat.i - x, threat.j - x])
-
-                    # threat is negative i positive j compared to king
-                    elif delta_i < 0 < delta_j:
-                        for x in range(num_between):
-                            pbsquares.append(self[threat.i + x, threat.j - x])
-
-                    # threat is negative i negative j compared to king
-                    elif delta_i < 0 > delta_j:
-                        for x in range(num_between):
-                            pbsquares.append(self[threat.i + x, threat.j + x])
-
-                    # threat is positive i negative j compared to king
-                    elif delta_i > 0 > delta_j:
-                        for x in range(num_between):
-                            pbsquares.append(self[threat.i - x, threat.j + x])
+                # the squares between the (sliding) checker and the king — any of
+                # which a friendly piece could interpose on to block the check
+                pbsquares = self._squares_between(king_square, threat)
 
                 # if any of the possible blocking squares (pbsquares) are blockable, returns false
                 for pbsquare in pbsquares:

--- a/src/chesssnake/engine/errors.py
+++ b/src/chesssnake/engine/errors.py
@@ -9,6 +9,7 @@ class ChessError(Exception):
     Used to handle and distinguish errors within the chess logic or
     system-specific exceptions during gameplay or chess computation.
     """
+
     def __init__(self, message):
         super().__init__(message)
 
@@ -20,8 +21,9 @@ class InvalidNotationError(ChessError):
     This class represents an error thrown when the user provides input
     that does not conform to standard algebraic notation in chess.
     """
+
     def __init__(self, user_input):
-        super().__init__(f"\"{user_input}\" is not in valid algebraic notation")
+        super().__init__(f'"{user_input}" is not in valid algebraic notation')
 
 
 class GameOverError(ChessError):
@@ -31,6 +33,7 @@ class GameOverError(ChessError):
     This error is triggered when a player attempts to perform an illegal operation, such as making a move,
     offering a draw, or any other game-related action after the game has ended.
     """
+
     def __init__(self):
         super().__init__("The game is over. You cannot do anything else.")
 
@@ -46,6 +49,7 @@ class PieceOnSquareError(ChessError):
     This exception handles cases where placement or movement of pieces violates the rules
     concerning square occupancy in chess games.
     """
+
     def __init__(self, square, is_same_color):
         if is_same_color:
             super().__init__(f"There is already a piece on {square.c_notation}")
@@ -61,6 +65,7 @@ class NothingToCaptureError(ChessError):
     This exception indicates that a capture move has been attempted on a square
     where no piece is present.
     """
+
     def __init__(self, square):
         super().__init__(f"There is not a piece to capture on {square.c_notation}")
 
@@ -72,8 +77,11 @@ class CaptureOwnPieceError(ChessError):
     This exception indicates that a player is trying to make an invalid move
     by attempting to capture one of their own pieces.
     """
+
     def __init__(self, square):
-        super().__init__(f"The piece on {square.c_notation} belongs to the player. Players cannot capture their own pieces")
+        super().__init__(
+            f"The piece on {square.c_notation} belongs to the player. Players cannot capture their own pieces"
+        )
 
 
 class PieceNotFoundError(ChessError):
@@ -85,6 +93,7 @@ class PieceNotFoundError(ChessError):
     specified square. It provides a descriptive error message for debugging
     or informational purposes.
     """
+
     def __init__(self, square, piecetype):
         piece = PieceType(piecetype).full_name
         super().__init__(f"No {piece}s can move to {square.c_notation}")
@@ -99,6 +108,7 @@ class MultiplePiecesFoundError(ChessError):
     same type to the same square, indicating ambiguity in the move notation. It
     provides detailed information about the conflicting pieces and their positions.
     """
+
     def __init__(self, square, found):
         piece = PieceType(found[0].piece.piecetype).full_name
         message = f"Multiple {piece}s can move to {square.c_notation}. The {piece}s are:"
@@ -116,6 +126,7 @@ class PromotionError(ChessError):
     promotion outside the opponent's back rank or failing to promote upon
     reaching the opponent's back rank.
     """
+
     def __init__(self, invalid_promotion=False, need_promotion=False):
         if invalid_promotion:
             super().__init__("You cannot promote unless you are on your opponent's back rank")
@@ -134,10 +145,11 @@ class InvalidCastleError(ChessError):
     that is either not allowed by the rules of the game or is attempted under
     invalid conditions.
     """
+
     def __init__(self, side):
-        if side == 'K':
+        if side == "K":
             super().__init__("You cannot kingside castle")
-        elif side == 'Q':
+        elif side == "Q":
             super().__init__("You cannot queenside castle")
         else:
             super().__init__("You cannot castle that way")
@@ -151,6 +163,7 @@ class MoveIntoCheckError(ChessError):
     when a move is attempted which would cause the player's king to end
     up in check.
     """
+
     def __init__(self):
         super().__init__("Making that move would put you in check")
 
@@ -164,6 +177,7 @@ class DrawWrongTurnError(ChessError):
     valid when it is a player's turn. This error helps ensure the rules of chess
     are adhered to during gameplay.
     """
+
     def __init__(self):
         super().__init__("You can only offer a draw when it is your turn")
 
@@ -176,6 +190,7 @@ class DrawAlreadyOfferedError(ChessError):
     This error is used in the chess game logic to enforce the rule that a player
     cannot repeatedly offer a draw when it has already been proposed.
     """
+
     def __init__(self):
         super().__init__("You have already offered a draw")
 
@@ -187,5 +202,6 @@ class DrawNotOfferedError(ChessError):
     This class is specifically used in the context of chess applications to indicate
     that an operation requiring a draw offer cannot proceed because no draw was offered.
     """
+
     def __init__(self):
         super().__init__("You have not been offered a draw")

--- a/src/chesssnake/engine/game.py
+++ b/src/chesssnake/engine/game.py
@@ -32,16 +32,17 @@ class Game:
     :type draw: Color or None
     """
 
-    def __init__(self,
-                 white_id: int = 0,
-                 black_id: int = 1,
-                 group_id: int = 0,
-                 white_name: str = '',
-                 black_name: str = '',
-                 board: "Board | None" = None,
-                 turn: int = 0,
-                 draw: "int | None" = None,
-                 ):
+    def __init__(
+        self,
+        white_id: int = 0,
+        black_id: int = 1,
+        group_id: int = 0,
+        white_name: str = "",
+        black_name: str = "",
+        board: "Board | None" = None,
+        turn: int = 0,
+        draw: "int | None" = None,
+    ):
         """
         Initializes a new chess game.
 
@@ -151,7 +152,9 @@ class Game:
 
         if (self.draw == Color.WHITE and player_id == self.wid) or (self.draw == Color.BLACK and player_id == self.bid):
             raise ChessError.DrawAlreadyOfferedError()
-        elif (self.draw == Color.BLACK and player_id == self.wid) or (self.draw == Color.WHITE and player_id == self.bid):
+        elif (self.draw == Color.BLACK and player_id == self.wid) or (
+            self.draw == Color.WHITE and player_id == self.bid
+        ):
             self.draw_accept(player_id)
         elif not self.is_players_turn(player_id):
             raise ChessError.DrawWrongTurnError()
@@ -172,8 +175,11 @@ class Game:
         if self.board.status != GameStatus.IN_PLAY:
             raise ChessError.GameOverError()
 
-        if (self.draw == Color.WHITE and player_id == self.wid) or (
-                self.draw == Color.BLACK and player_id == self.bid) or self.draw is None:
+        if (
+            (self.draw == Color.WHITE and player_id == self.wid)
+            or (self.draw == Color.BLACK and player_id == self.bid)
+            or self.draw is None
+        ):
             raise ChessError.DrawNotOfferedError()
 
         self.board.status = GameStatus.DRAW  # Set game status to draw
@@ -192,8 +198,11 @@ class Game:
         if self.board.status != GameStatus.IN_PLAY:
             raise ChessError.GameOverError()
 
-        if (self.draw == Color.WHITE and player_id == self.wid) or (
-                self.draw == Color.BLACK and player_id == self.bid) or self.draw is None:
+        if (
+            (self.draw == Color.WHITE and player_id == self.wid)
+            or (self.draw == Color.BLACK and player_id == self.bid)
+            or self.draw is None
+        ):
             raise ChessError.DrawNotOfferedError()
 
         self.draw = None

--- a/src/chesssnake/engine/image.py
+++ b/src/chesssnake/engine/image.py
@@ -43,9 +43,7 @@ def _render_side(grid, small_font, flip, highlights):
         for y in range(8):
             piece = grid[x][y].piece
             if piece is not None:
-                board_img.alpha_composite(
-                    _piece_image(piece.piecetype.value, int(piece.color)), (TILE * y, TILE * x)
-                )
+                board_img.alpha_composite(_piece_image(piece.piecetype.value, int(piece.color)), (TILE * y, TILE * x))
 
             # rank number down the left edge
             if y == 0:

--- a/src/chesssnake/engine/move.py
+++ b/src/chesssnake/engine/move.py
@@ -28,6 +28,7 @@ class Move:
     :ivar en: Indicates whether this move is an en passant capture.
     :type en: bool
     """
+
     def __init__(self, move, player, board):
         """
         Initializes a move object based on the input move command, player, and the board.
@@ -59,10 +60,8 @@ class Move:
 
         # regular movement (not castling)
         if move != "0-0" and move != "0-0-0":
-
             if move[0] in "RNBQKP":
-
-                if move[0] == 'P' and move[-1] in "RNBQ":
+                if move[0] == "P" and move[-1] in "RNBQ":
                     promotion = move[-1]
                     coords = notation.get_coords(move[-3:-1])
 
@@ -80,33 +79,43 @@ class Move:
                 capture = False
 
                 # checks if there is a file limit, rank limit, or capture
-                for char in (move[1:-3] if (move[0] == 'P' and promotion is not None) else move[1:-2]):
+                for char in move[1:-3] if (move[0] == "P" and promotion is not None) else move[1:-2]:
                     if char in FILES:
                         file_limit = char
                         continue
                     elif char in RANKS:
                         rank_limit = char
                         continue
-                    elif char == 'x':
+                    elif char == "x":
                         capture = True
                         continue
 
                 try:
-                    if move[0] == 'R':
+                    if move[0] == "R":
                         square = Rook.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
-                    elif move[0] == 'N':
-                        square = Knight.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
-                    elif move[0] == 'B':
-                        square = Bishop.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
-                    elif move[0] == 'Q':
-                        square = Queen.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
-                    elif move[0] == 'K':
+                    elif move[0] == "N":
+                        square = Knight.find_one(
+                            board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit
+                        )
+                    elif move[0] == "B":
+                        square = Bishop.find_one(
+                            board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit
+                        )
+                    elif move[0] == "Q":
+                        square = Queen.find_one(
+                            board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit
+                        )
+                    elif move[0] == "K":
                         square = King.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
-                    elif move[0] == 'P':
+                    elif move[0] == "P":
                         try:
-                            square = Pawn.find_one(board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit)
+                            square = Pawn.find_one(
+                                board, to, player, capture, file_limit=file_limit, rank_limit=rank_limit
+                            )
                         except errors.NothingToCaptureError:
-                            square = Pawn.find_one(board, to, player, capture, en=True, file_limit=file_limit, rank_limit=rank_limit)
+                            square = Pawn.find_one(
+                                board, to, player, capture, en=True, file_limit=file_limit, rank_limit=rank_limit
+                            )
                             en = True
 
                 except errors.ChessError as e:
@@ -119,7 +128,6 @@ class Move:
                     # makes sure the player cannot move a pawn to opponent's back rank without promoting
                     if piece.piecetype == PieceType.PAWN and i == (0 if player == 0 else 7) and promotion is None:
                         raise errors.PromotionError(need_promotion=True)
-
 
             # pawn exclusive movement
             elif move[0] in FILES:
@@ -139,7 +147,7 @@ class Move:
                 i, j = coords
                 to = board[i, j]
 
-                capture = True if move[1] == 'x' else False
+                capture = True if move[1] == "x" else False
 
                 try:
                     square = Pawn.find_one(board, to, player, capture, file_limit=file_limit)
@@ -156,28 +164,25 @@ class Move:
 
         # castling
         else:
-
             x = 7 if player == 0 else 0
 
             piece = board.find_king(player).piece
 
             # king side castle
             if move == "0-0":
-
                 prev, to = board[x, 4], board[x, 6]
-                castle = 'K'
+                castle = "K"
 
-                if not piece.can_castle(board, 'K'):
-                    raise errors.InvalidCastleError('K')
+                if not piece.can_castle(board, "K"):
+                    raise errors.InvalidCastleError("K")
 
             # queen side castle
             else:
-
                 prev, to = board[x, 4], board[x, 2]
-                castle = 'Q'
+                castle = "Q"
 
-                if not piece.can_castle(board, 'Q'):
-                    raise errors.InvalidCastleError('Q')
+                if not piece.can_castle(board, "Q"):
+                    raise errors.InvalidCastleError("Q")
 
         self.piece = piece
         self.prev = prev

--- a/src/chesssnake/engine/notation.py
+++ b/src/chesssnake/engine/notation.py
@@ -98,9 +98,9 @@ def is_valid_c_notation(movename: str) -> bool:
         return False
 
     # cuts off check or checkmate symbol from tail end
-    if '+' == movename[-1]:
+    if "+" == movename[-1]:
         movename = movename[:-1]
-    if '#' == movename[-1]:
+    if "#" == movename[-1]:
         movename = movename[:-1]
 
     # if the move is a castling move, returns true
@@ -114,13 +114,12 @@ def is_valid_c_notation(movename: str) -> bool:
 
     # if a pawn...
     elif movename[0] in FILES:
-
         # if there is a promotion, it is removed from the string
         if movename[-1] in "RNBQ":
             movename = movename[:-1]
 
         # if there is a capture sign as the second letter...
-        if movename[1] == 'x':
+        if movename[1] == "x":
             # temp is everything that isn't square location or piecetype
             temp = movename[1:-2]
 
@@ -146,9 +145,8 @@ def is_valid_c_notation(movename: str) -> bool:
 
     # if temp is two characters...
     elif len(temp) == 2:
-
         # if temp is a capture and the first letter of temp is not valid, returns false
-        if 'x' == temp[1] and temp[0] not in FILES + RANKS:
+        if "x" == temp[1] and temp[0] not in FILES + RANKS:
             return False
 
         # if temp is a specification move and uses invalid characters, returns false
@@ -157,9 +155,8 @@ def is_valid_c_notation(movename: str) -> bool:
 
     # if temp is three characters...
     elif len(temp) == 3:
-
         # if temp is a specification and capture move and uses invalid specification, returns false
-        if temp[0] not in FILES or temp[1] not in RANKS or temp[2] != 'x':
+        if temp[0] not in FILES or temp[1] not in RANKS or temp[2] != "x":
             return False
 
     # if temp is more than 3 characters, it is invalid

--- a/src/chesssnake/engine/pieces.py
+++ b/src/chesssnake/engine/pieces.py
@@ -63,7 +63,8 @@ def _reachable(squares, color):
 def _find(candidate_squares, piecetype, color, file_limit, rank_limit):
     """Squares among ``candidate_squares`` holding ``piecetype``/``color`` matching disambiguation."""
     return [
-        sq for sq in candidate_squares
+        sq
+        for sq in candidate_squares
         if sq is not None
         and sq.piece is not None
         and sq.piece.piecetype == piecetype
@@ -137,8 +138,7 @@ class Piece:
             king_threats2 = board.threats_on(board.find_king(self.color), self.color)
 
         # the threat present in exactly one of the two scans is the one being blocked
-        king_threats = [t for t in king_threats1 + king_threats2
-                        if t not in king_threats1 or t not in king_threats2]
+        king_threats = [t for t in king_threats1 + king_threats2 if t not in king_threats1 or t not in king_threats2]
 
         if len(king_threats) != 1:
             return False
@@ -196,8 +196,7 @@ class Rook(Piece):
     def find_all(cls, board, square, color, file_limit=None, rank_limit=None):
         """Rook squares of ``color`` that could reach ``square`` (never raises)."""
         color = Color(color)
-        return _find(_slide(board, square.i, square.j, ORTHOGONAL),
-                     PieceType.ROOK, color, file_limit, rank_limit)
+        return _find(_slide(board, square.i, square.j, ORTHOGONAL), PieceType.ROOK, color, file_limit, rank_limit)
 
 
 class Knight(Piece):
@@ -222,8 +221,7 @@ class Knight(Piece):
     def find_all(cls, board, square, color, file_limit=None, rank_limit=None):
         """Knight squares of ``color`` that could reach ``square`` (never raises)."""
         color = Color(color)
-        return _find(_step(board, square.i, square.j, KNIGHT_JUMPS),
-                     PieceType.KNIGHT, color, file_limit, rank_limit)
+        return _find(_step(board, square.i, square.j, KNIGHT_JUMPS), PieceType.KNIGHT, color, file_limit, rank_limit)
 
 
 class Bishop(Piece):
@@ -248,8 +246,7 @@ class Bishop(Piece):
     def find_all(cls, board, square, color, file_limit=None, rank_limit=None):
         """Bishop squares of ``color`` that could reach ``square`` (never raises)."""
         color = Color(color)
-        return _find(_slide(board, square.i, square.j, DIAGONAL),
-                     PieceType.BISHOP, color, file_limit, rank_limit)
+        return _find(_slide(board, square.i, square.j, DIAGONAL), PieceType.BISHOP, color, file_limit, rank_limit)
 
 
 class Queen(Piece):
@@ -274,8 +271,7 @@ class Queen(Piece):
     def find_all(cls, board, square, color, file_limit=None, rank_limit=None):
         """Queen squares of ``color`` that could reach ``square`` (never raises)."""
         color = Color(color)
-        return _find(_slide(board, square.i, square.j, ALL_DIRECTIONS),
-                     PieceType.QUEEN, color, file_limit, rank_limit)
+        return _find(_slide(board, square.i, square.j, ALL_DIRECTIONS), PieceType.QUEEN, color, file_limit, rank_limit)
 
 
 class King(Piece):
@@ -313,37 +309,35 @@ class King(Piece):
         x = 7 if self.color == Color.WHITE else 0
 
         # king side castle...
-        if direction == 'K':
-
+        if direction == "K":
             king_rook_square = board[x, 0]
             between_square1, between_square2 = board[x, 5], board[x, 6]
 
             if (
-                    king_rook_square.piece is not None
-                    and king_rook_square.piece.piecetype == PieceType.ROOK
-                    and king_rook_square.piece.color == self.color
-                    and not king_rook_square.piece.moved
-                    and between_square1.piece is None
-                    and len(board.threats_on(between_square1, self.color)) == 0
-                    and between_square2.piece is None
+                king_rook_square.piece is not None
+                and king_rook_square.piece.piecetype == PieceType.ROOK
+                and king_rook_square.piece.color == self.color
+                and not king_rook_square.piece.moved
+                and between_square1.piece is None
+                and len(board.threats_on(between_square1, self.color)) == 0
+                and between_square2.piece is None
             ):
                 return True
 
         # queen side castle...
-        elif direction == 'Q':
-
+        elif direction == "Q":
             queen_rook_square = board[x, 7]
             between_square1, between_square2, between_square3 = board[x, 1], board[x, 2], board[x, 3]
 
             if (
-                    queen_rook_square.piece is not None
-                    and queen_rook_square.piece.piecetype == PieceType.ROOK
-                    and queen_rook_square.piece.color == self.color
-                    and not queen_rook_square.piece.moved
-                    and between_square1.piece is None
-                    and between_square2.piece is None
-                    and len(board.threats_on(between_square2, self.color)) == 0
-                    and between_square3.piece is None
+                queen_rook_square.piece is not None
+                and queen_rook_square.piece.piecetype == PieceType.ROOK
+                and queen_rook_square.piece.color == self.color
+                and not queen_rook_square.piece.moved
+                and between_square1.piece is None
+                and between_square2.piece is None
+                and len(board.threats_on(between_square2, self.color)) == 0
+                and between_square3.piece is None
             ):
                 return True
 
@@ -353,8 +347,7 @@ class King(Piece):
     def find_all(cls, board, square, color, file_limit=None, rank_limit=None):
         """King squares of ``color`` adjacent to ``square`` (never raises)."""
         color = Color(color)
-        return _find(_step(board, square.i, square.j, ALL_DIRECTIONS),
-                     PieceType.KING, color, file_limit, rank_limit)
+        return _find(_step(board, square.i, square.j, ALL_DIRECTIONS), PieceType.KING, color, file_limit, rank_limit)
 
 
 class Pawn(Piece):
@@ -368,8 +361,11 @@ class Pawn(Piece):
     def threatens(self, square, board):
         """The two diagonally-forward squares this pawn attacks (ignoring pins)."""
         forward = -1 if self.color == Color.WHITE else 1
-        squares = (sq for sq in (board[square.i + forward, square.j + 1],
-                                 board[square.i + forward, square.j - 1]) if sq is not None)
+        squares = (
+            sq
+            for sq in (board[square.i + forward, square.j + 1], board[square.i + forward, square.j - 1])
+            if sq is not None
+        )
         return _reachable(squares, self.color)
 
     def can_move(self, square, board):
@@ -379,8 +375,9 @@ class Pawn(Piece):
             king_threats1 = board.threats_on(board.find_king(self.color), self.color)
             with board.lifted(square):
                 king_threats2 = board.threats_on(board.find_king(self.color), self.color)
-            king_threats = [t for t in king_threats1 + king_threats2
-                            if t not in king_threats1 or t not in king_threats2]
+            king_threats = [
+                t for t in king_threats1 + king_threats2 if t not in king_threats1 or t not in king_threats2
+            ]
             return len(king_threats) > 1 and king_threats[0] in self.threatens(square, board)
 
         forward = -1 if self.color == Color.WHITE else 1
@@ -409,8 +406,7 @@ class Pawn(Piece):
         behind = 1 if color == Color.WHITE else -1
 
         if capture:
-            candidates = (board[square.i + behind, square.j + 1],
-                          board[square.i + behind, square.j - 1])
+            candidates = (board[square.i + behind, square.j + 1], board[square.i + behind, square.j - 1])
             return _find(candidates, PieceType.PAWN, color, file_limit, rank_limit)
 
         # forward push: the pawn is one square behind, or two if the square between is empty

--- a/src/chesssnake/engine/square.py
+++ b/src/chesssnake/engine/square.py
@@ -29,6 +29,7 @@ class Square:
         the square is empty.
     :type piece: Optional[Piece]
     """
+
     def __init__(self, i: int, j: int, piece=None):
         """
         Initializes a square on a chessboard.

--- a/src/chesssnake/remote/client.py
+++ b/src/chesssnake/remote/client.py
@@ -63,17 +63,25 @@ class ApiClient:
     # --- games -------------------------------------------------------------
 
     def get_or_create_game(self, group_id, white_id, black_id, white_name="", black_name=""):
-        return self._request("POST", "/games", json={
-            "group_id": group_id, "white_id": white_id, "black_id": black_id,
-            "white_name": white_name, "black_name": black_name,
-        })
+        return self._request(
+            "POST",
+            "/games",
+            json={
+                "group_id": group_id,
+                "white_id": white_id,
+                "black_id": black_id,
+                "white_name": white_name,
+                "black_name": black_name,
+            },
+        )
 
     def update_game(self, group_id, white_id, black_id, state):
         return self._request("PUT", f"/games/{group_id}/{white_id}/{black_id}", json=state)
 
     def update_draw(self, group_id, white_id, black_id, draw, status):
         return self._request(
-            "PATCH", f"/games/{group_id}/{white_id}/{black_id}/draw",
+            "PATCH",
+            f"/games/{group_id}/{white_id}/{black_id}/draw",
             json={"draw": draw, "status": status},
         )
 
@@ -94,9 +102,15 @@ class ApiClient:
     # --- challenges --------------------------------------------------------
 
     def challenge(self, challenger, challenged, group_id=0):
-        data = self._request("POST", "/challenges", json={
-            "group_id": group_id, "challenger": challenger, "challenged": challenged,
-        })
+        data = self._request(
+            "POST",
+            "/challenges",
+            json={
+                "group_id": group_id,
+                "challenger": challenger,
+                "challenged": challenged,
+            },
+        )
         return data["accepted"]
 
     def challenge_exists(self, player1, player2, group_id=0):
@@ -104,6 +118,12 @@ class ApiClient:
         return data["challenge"]
 
     def delete_challenge(self, challenger, challenged, group_id=0):
-        return self._request("DELETE", "/challenges", json={
-            "group_id": group_id, "challenger": challenger, "challenged": challenged,
-        })
+        return self._request(
+            "DELETE",
+            "/challenges",
+            json={
+                "group_id": group_id,
+                "challenger": challenger,
+                "challenged": challenged,
+            },
+        )

--- a/src/chesssnake/remote/game.py
+++ b/src/chesssnake/remote/game.py
@@ -20,12 +20,10 @@ def _make_client(api_url=None, client=None):
     if client is not None:
         return client
     from .client import ApiClient
+
     url = api_url or os.getenv("CHESSSNAKE_API_URL")
     if not url:
-        raise ValueError(
-            "A remote game requires an api_url argument or the CHESSSNAKE_API_URL "
-            "environment variable."
-        )
+        raise ValueError("A remote game requires an api_url argument or the CHESSSNAKE_API_URL environment variable.")
     return ApiClient(url)
 
 
@@ -39,8 +37,18 @@ class Game(BaseGame):
     :param api_url: Base URL of the api-endpoint. Falls back to ``CHESSSNAKE_API_URL``.
     """
 
-    def __init__(self, white_id=0, black_id=1, group_id=0, white_name='', black_name='',
-                 remote=False, auto_sync=False, api_url=None, _client=None):
+    def __init__(
+        self,
+        white_id=0,
+        black_id=1,
+        group_id=0,
+        white_name="",
+        black_name="",
+        remote=False,
+        auto_sync=False,
+        api_url=None,
+        _client=None,
+    ):
         self.remote = remote or auto_sync
         self.auto_sync = auto_sync
         self._client = None
@@ -49,7 +57,9 @@ class Game(BaseGame):
             self._client = _make_client(api_url, _client)
             state = self._client.get_or_create_game(group_id, white_id, black_id, white_name, black_name)
             super().__init__(
-                white_id, black_id, group_id,
+                white_id,
+                black_id,
+                group_id,
                 white_name=state["wname"] if state["wname"] is not None else white_name,
                 black_name=state["bname"] if state["bname"] is not None else black_name,
                 board=self._board_from_state(state),
@@ -104,14 +114,16 @@ class Game(BaseGame):
     def draw_offer(self, player_id):
         super().draw_offer(player_id)
         if self.auto_sync:
-            self._client.update_draw(self.gid, self.wid, self.bid,
-                                    int(self.draw) if self.draw is not None else None, int(self.board.status))
+            self._client.update_draw(
+                self.gid, self.wid, self.bid, int(self.draw) if self.draw is not None else None, int(self.board.status)
+            )
 
     def draw_accept(self, player_id):
         super().draw_accept(player_id)
         if self.auto_sync:
-            self._client.update_draw(self.gid, self.wid, self.bid,
-                                    int(self.draw) if self.draw is not None else None, int(self.board.status))
+            self._client.update_draw(
+                self.gid, self.wid, self.bid, int(self.draw) if self.draw is not None else None, int(self.board.status)
+            )
 
     def draw_decline(self, player_id):
         super().draw_decline(player_id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,7 @@ def api_client():
 @pytest.fixture(autouse=True)
 def clean_tables(api_client):
     from chesssnake.db.sql import execute_psql
+
     execute_psql("TRUNCATE Games, Challenges")
     yield
 
@@ -47,4 +48,5 @@ def clean_tables(api_client):
 def remote_client(api_client):
     """An ApiClient wired to drive the in-process app through the TestClient."""
     from chesssnake.remote.client import ApiClient
+
     return ApiClient("", session=api_client)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -84,7 +84,9 @@ def test_current_games_and_exists(api_client):
 def test_challenge_lifecycle(api_client):
     first = api_client.post("/challenges", json={"group_id": 10, "challenger": 100, "challenged": 200})
     assert first.json()["accepted"] is False
-    assert api_client.get("/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"] is not None
+    assert (
+        api_client.get("/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"] is not None
+    )
 
     accept = api_client.post("/challenges", json={"group_id": 10, "challenger": 200, "challenged": 100})
     assert accept.json()["accepted"] is True
@@ -99,6 +101,6 @@ def test_self_challenge_conflicts(api_client):
 
 def test_invalid_id_returns_422(api_client):
     # Beyond PostgreSQL BIGINT range -> SQLIdError -> 422.
-    resp = api_client.post("/games", json={"group_id": 0, "white_id": 10 ** 19, "black_id": 2})
+    resp = api_client.post("/games", json={"group_id": 0, "white_id": 10**19, "black_id": 2})
     assert resp.status_code == 422
     assert resp.json()["error_type"] == "SQLIdError"

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,6 +1,10 @@
 """Integration tests for the FastAPI api-endpoint hitting a real Postgres."""
 
+import pytest
+
 from chesssnake.db import INITIAL_BOARD
+
+pytestmark = pytest.mark.integration
 
 
 def test_health(api_client):

--- a/tests/integration/test_remote_game.py
+++ b/tests/integration/test_remote_game.py
@@ -10,6 +10,8 @@ import pytest
 from chesssnake.db import errors as GameError
 from chesssnake.remote.game import Challenge, Game
 
+pytestmark = pytest.mark.integration
+
 
 def make_game(remote_client, **kwargs):
     kwargs.setdefault("remote", True)

--- a/tests/integration/test_remote_game.py
+++ b/tests/integration/test_remote_game.py
@@ -20,6 +20,7 @@ def make_game(remote_client, **kwargs):
 
 def piece_at(board, c_notation):
     from chesssnake import engine as Chess
+
     i, j = Chess.Board.get_coords(c_notation)
     return board[i, j].piece
 

--- a/tests/unit/test_coords_and_square.py
+++ b/tests/unit/test_coords_and_square.py
@@ -1,6 +1,5 @@
 """Unit tests for coordinate <-> notation conversion and the Square class."""
 
-
 from chesssnake.engine import Board, Square
 
 

--- a/tests/unit/test_endgame.py
+++ b/tests/unit/test_endgame.py
@@ -13,11 +13,16 @@ def test_fools_mate_is_checkmate():
 
 def test_back_rank_checkmate(make_board):
     # Black king boxed in by its own pawns; white rook delivers mate on the 8th rank.
-    board = make_board({
-        (7, 0): "R0", (7, 4): "K0",           # white rook a1, white king e1
-        (0, 6): "K1",                          # black king g8
-        (1, 5): "P1", (1, 6): "P1", (1, 7): "P1",  # black pawns f7 g7 h7
-    })
+    board = make_board(
+        {
+            (7, 0): "R0",
+            (7, 4): "K0",  # white rook a1, white king e1
+            (0, 6): "K1",  # black king g8
+            (1, 5): "P1",
+            (1, 6): "P1",
+            (1, 7): "P1",  # black pawns f7 g7 h7
+        }
+    )
     g = Game(board=board, turn=0)
     g.move("Ra8")
     assert g.board.status == 1  # checkmate
@@ -25,11 +30,13 @@ def test_back_rank_checkmate(make_board):
 
 def test_stalemate_detection(make_board):
     # Black king h8 with no legal moves and not in check after white plays Qg6.
-    board = make_board({
-        (0, 7): "K1",   # black king h8
-        (1, 5): "K0",   # white king f7
-        (2, 0): "Q0",   # white queen a6
-    })
+    board = make_board(
+        {
+            (0, 7): "K1",  # black king h8
+            (1, 5): "K0",  # white king f7
+            (2, 0): "Q0",  # white queen a6
+        }
+    )
     g = Game(board=board, turn=0)
     g.move("Qg6")
     assert g.board.status == 2  # stalemate
@@ -43,13 +50,19 @@ def test_pawn_can_block_check_is_not_mate(make_board):
     #
     # Black king e5 is boxed by its own pawns; the white rook on a5 checks along
     # rank 5. The sole legal reply is d6-d5, interposing the pawn.
-    board = make_board({
-        (3, 4): "K1",                              # black king e5
-        (3, 0): "R0",                              # white rook a5 (checks along rank 5)
-        (2, 3): "P1", (2, 4): "P1", (2, 5): "P1",  # black pawns d6 e6 f6
-        (4, 3): "P1", (4, 4): "P1", (4, 5): "P1",  # black pawns d4 e4 f4
-        (7, 4): "K0",                              # white king e1
-    })
+    board = make_board(
+        {
+            (3, 4): "K1",  # black king e5
+            (3, 0): "R0",  # white rook a5 (checks along rank 5)
+            (2, 3): "P1",
+            (2, 4): "P1",
+            (2, 5): "P1",  # black pawns d6 e6 f6
+            (4, 3): "P1",
+            (4, 4): "P1",
+            (4, 5): "P1",  # black pawns d4 e4 f4
+            (7, 4): "K0",  # white king e1
+        }
+    )
     assert board.check_for_check(1) is True
     assert board.check_for_mate(1) is False  # d6-d5 blocks the check
 
@@ -63,13 +76,16 @@ def test_diagonal_check_can_be_blocked_is_not_mate(make_board):
     # Black king h8 is checked by the white bishop a1 along the long diagonal; the
     # king is boxed (own pawns g8/h7, and g7 lies on the checking diagonal). The one
     # defense is Rb2, interposing the rook on the diagonal.
-    board = make_board({
-        (0, 7): "K1",                 # black king h8
-        (7, 0): "B0",                 # white bishop a1 (checks along a1-h8)
-        (0, 6): "P1", (1, 7): "P1",   # black pawns g8, h7 (box the king)
-        (0, 1): "R1",                 # black rook b8 -> can interpose with Rb2
-        (7, 4): "K0",                 # white king e1
-    })
+    board = make_board(
+        {
+            (0, 7): "K1",  # black king h8
+            (7, 0): "B0",  # white bishop a1 (checks along a1-h8)
+            (0, 6): "P1",
+            (1, 7): "P1",  # black pawns g8, h7 (box the king)
+            (0, 1): "R1",  # black rook b8 -> can interpose with Rb2
+            (7, 4): "K0",  # white king e1
+        }
+    )
     assert board.check_for_check(1) is True
     assert board.check_for_mate(1) is False  # Rb2 blocks the diagonal
 
@@ -81,12 +97,14 @@ def test_diagonal_checkmate_is_mate(make_board):
     # White bishop c3 checks the black king h8 along c3-h8; the white queen f7 covers
     # every escape (g8, h7, g7). Nothing can interpose on d4/e5/f6/g7 or capture the
     # bishop -> checkmate.
-    board = make_board({
-        (0, 7): "K1",   # black king h8
-        (5, 2): "B0",   # white bishop c3 (checks along c3-h8)
-        (1, 5): "Q0",   # white queen f7 (covers g8/h7/g7)
-        (7, 4): "K0",   # white king e1
-    })
+    board = make_board(
+        {
+            (0, 7): "K1",  # black king h8
+            (5, 2): "B0",  # white bishop c3 (checks along c3-h8)
+            (1, 5): "Q0",  # white queen f7 (covers g8/h7/g7)
+            (7, 4): "K0",  # white king e1
+        }
+    )
     assert board.check_for_check(1) is True
     assert board.check_for_mate(1) is True
 
@@ -94,13 +112,15 @@ def test_diagonal_checkmate_is_mate(make_board):
 def test_diagonal_check_can_be_captured_is_not_mate(make_board):
     # A diagonal check answered by capturing the checker is not mate.
     # Black rook h3 shares the 3rd rank with the checking bishop c3 -> Rxc3.
-    board = make_board({
-        (0, 7): "K1",   # black king h8
-        (5, 2): "B0",   # white bishop c3 (checks along c3-h8)
-        (1, 5): "Q0",   # white queen f7 (covers the king's escapes)
-        (5, 7): "R1",   # black rook h3 -> can capture with Rxc3
-        (7, 4): "K0",   # white king e1
-    })
+    board = make_board(
+        {
+            (0, 7): "K1",  # black king h8
+            (5, 2): "B0",  # white bishop c3 (checks along c3-h8)
+            (1, 5): "Q0",  # white queen f7 (covers the king's escapes)
+            (5, 7): "R1",  # black rook h3 -> can capture with Rxc3
+            (7, 4): "K0",  # white king e1
+        }
+    )
     assert board.check_for_check(1) is True
     assert board.check_for_mate(1) is False  # Rxc3 removes the checker
 

--- a/tests/unit/test_endgame.py
+++ b/tests/unit/test_endgame.py
@@ -54,6 +54,57 @@ def test_pawn_can_block_check_is_not_mate(make_board):
     assert board.check_for_mate(1) is False  # d6-d5 blocks the check
 
 
+def test_diagonal_check_can_be_blocked_is_not_mate(make_board):
+    # Regression: a *diagonal* check that can be answered by interposing a piece
+    # must not be scored as mate. The blocking-square math for diagonals was doubly
+    # broken (it used `king_square.j` where it meant `.i`, and was off by one), so a
+    # blockable diagonal check could be misreported as checkmate.
+    #
+    # Black king h8 is checked by the white bishop a1 along the long diagonal; the
+    # king is boxed (own pawns g8/h7, and g7 lies on the checking diagonal). The one
+    # defense is Rb2, interposing the rook on the diagonal.
+    board = make_board({
+        (0, 7): "K1",                 # black king h8
+        (7, 0): "B0",                 # white bishop a1 (checks along a1-h8)
+        (0, 6): "P1", (1, 7): "P1",   # black pawns g8, h7 (box the king)
+        (0, 1): "R1",                 # black rook b8 -> can interpose with Rb2
+        (7, 4): "K0",                 # white king e1
+    })
+    assert board.check_for_check(1) is True
+    assert board.check_for_mate(1) is False  # Rb2 blocks the diagonal
+
+
+def test_diagonal_checkmate_is_mate(make_board):
+    # Positive counterpart: a genuine long-range diagonal mate must still be scored
+    # as mate (guards against a fix that simply never reports diagonal mates).
+    #
+    # White bishop c3 checks the black king h8 along c3-h8; the white queen f7 covers
+    # every escape (g8, h7, g7). Nothing can interpose on d4/e5/f6/g7 or capture the
+    # bishop -> checkmate.
+    board = make_board({
+        (0, 7): "K1",   # black king h8
+        (5, 2): "B0",   # white bishop c3 (checks along c3-h8)
+        (1, 5): "Q0",   # white queen f7 (covers g8/h7/g7)
+        (7, 4): "K0",   # white king e1
+    })
+    assert board.check_for_check(1) is True
+    assert board.check_for_mate(1) is True
+
+
+def test_diagonal_check_can_be_captured_is_not_mate(make_board):
+    # A diagonal check answered by capturing the checker is not mate.
+    # Black rook h3 shares the 3rd rank with the checking bishop c3 -> Rxc3.
+    board = make_board({
+        (0, 7): "K1",   # black king h8
+        (5, 2): "B0",   # white bishop c3 (checks along c3-h8)
+        (1, 5): "Q0",   # white queen f7 (covers the king's escapes)
+        (5, 7): "R1",   # black rook h3 -> can capture with Rxc3
+        (7, 4): "K0",   # white king e1
+    })
+    assert board.check_for_check(1) is True
+    assert board.check_for_mate(1) is False  # Rxc3 removes the checker
+
+
 def test_ongoing_game_has_no_terminal_status():
     g = Game()
     g.move("e4")

--- a/tests/unit/test_game_flow.py
+++ b/tests/unit/test_game_flow.py
@@ -8,7 +8,7 @@ from chesssnake.engine import errors as ChessError
 
 def test_new_game_defaults():
     g = Game(white_name="A", black_name="B")
-    assert g.turn == 0          # white to move
+    assert g.turn == 0  # white to move
     assert g.draw is None
     assert g.board.status == 0  # in play
 
@@ -46,10 +46,10 @@ def test_is_players_turn():
 
 def test_draw_offer_and_accept_ends_in_draw():
     g = Game(white_id=10, black_id=20)
-    g.draw_offer(10)             # white (to move) offers
+    g.draw_offer(10)  # white (to move) offers
     assert g.draw == 0
-    g.draw_offer(20)             # black offering back accepts the draw
-    assert g.board.status == 2   # draw / stalemate status
+    g.draw_offer(20)  # black offering back accepts the draw
+    assert g.board.status == 2  # draw / stalemate status
 
 
 def test_double_draw_offer_raises():
@@ -62,7 +62,7 @@ def test_double_draw_offer_raises():
 def test_draw_offer_out_of_turn_raises():
     g = Game(white_id=10, black_id=20)  # white to move
     with pytest.raises(ChessError.DrawWrongTurnError):
-        g.draw_offer(20)                # black offers out of turn
+        g.draw_offer(20)  # black offers out of turn
 
 
 def test_decline_with_no_offer_raises():

--- a/tests/unit/test_notation.py
+++ b/tests/unit/test_notation.py
@@ -7,30 +7,53 @@ from chesssnake.engine import Move
 valid = Move.is_valid_c_notation
 
 
-@pytest.mark.parametrize("move", [
-    "e4", "d5", "a3", "h6",          # simple pawn pushes
-    "Nf3", "Nc6", "Bb5", "Qh4", "Ke2", "Ra1",  # piece moves
-    "exd5", "Nxe5", "Qxf7", "Bxc6",  # captures
-    "Rad1", "R1a3", "Nbd2",          # disambiguation (file / rank)
-    "e8Q", "b8N", "exd8Q",           # promotions (concatenated piece letter)
-    "0-0", "0-0-0",                  # castling
-    "Nf3+", "Qh4#",                  # check / checkmate annotations
-])
+@pytest.mark.parametrize(
+    "move",
+    [
+        "e4",
+        "d5",
+        "a3",
+        "h6",  # simple pawn pushes
+        "Nf3",
+        "Nc6",
+        "Bb5",
+        "Qh4",
+        "Ke2",
+        "Ra1",  # piece moves
+        "exd5",
+        "Nxe5",
+        "Qxf7",
+        "Bxc6",  # captures
+        "Rad1",
+        "R1a3",
+        "Nbd2",  # disambiguation (file / rank)
+        "e8Q",
+        "b8N",
+        "exd8Q",  # promotions (concatenated piece letter)
+        "0-0",
+        "0-0-0",  # castling
+        "Nf3+",
+        "Qh4#",  # check / checkmate annotations
+    ],
+)
 def test_valid_notation_accepted(move):
     assert valid(move) is True
 
 
-@pytest.mark.parametrize("move", [
-    "",             # empty
-    "e",            # too short
-    "e9",           # rank out of range
-    "i4",           # file out of range
-    "Xf3",          # bogus piece letter
-    "O-O",          # castling must use zeros, not letter O
-    "Zz9",          # nonsense
-    "e4e5",         # two squares glued together
-    "Nf9",          # invalid rank on a piece move
-])
+@pytest.mark.parametrize(
+    "move",
+    [
+        "",  # empty
+        "e",  # too short
+        "e9",  # rank out of range
+        "i4",  # file out of range
+        "Xf3",  # bogus piece letter
+        "O-O",  # castling must use zeros, not letter O
+        "Zz9",  # nonsense
+        "e4e5",  # two squares glued together
+        "Nf9",  # invalid rank on a piece move
+    ],
+)
 def test_invalid_notation_rejected(move):
     assert valid(move) is False
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -42,11 +42,11 @@ def test_en_passant_capture():
     g.move("e4")
     g.move("Nf6")
     g.move("e5")
-    g.move("d5")        # black double-steps next to the white e5 pawn
-    g.move("exd6")      # white captures en passant
-    assert piece_at(g.board, "d6") is not None       # capturing pawn advanced
+    g.move("d5")  # black double-steps next to the white e5 pawn
+    g.move("exd6")  # white captures en passant
+    assert piece_at(g.board, "d6") is not None  # capturing pawn advanced
     assert piece_at(g.board, "d6").piecetype.value == "P"
-    assert piece_at(g.board, "d5") is None           # captured pawn removed
+    assert piece_at(g.board, "d5") is None  # captured pawn removed
 
 
 def test_kingside_castle():

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -34,11 +34,11 @@ def test_moved_flag_set_for_rook_that_returned_home():
     # The `moved` string flags a king/rook that is on its home square and has
     # moved (so castling rights are correctly lost even if the rook returns).
     board = Board()
-    board.move("a4", 0)    # open the a-file in front of the a1 rook
-    board.move("Ra3", 0)   # a1 rook steps out
-    board.move("Ra1", 0)   # ...and returns home, now flagged as moved
+    board.move("a4", 0)  # open the a-file in front of the a1 rook
+    board.move("Ra3", 0)  # a1 rook steps out
+    board.move("Ra1", 0)  # ...and returns home, now flagged as moved
 
     _, moved = Board.disassemble_board(board)
-    assert moved[0] == "1"          # white a1 rook has moved
-    assert moved[1] == "0"          # white king has not
-    assert moved[3:] == "000"       # black king/rooks untouched
+    assert moved[0] == "1"  # white a1 rook has moved
+    assert moved[1] == "0"  # white king has not
+    assert moved[3:] == "000"  # black king/rooks untouched

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -199,8 +208,10 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pgserver" },
+    { name = "pre-commit" },
     { name = "psycopg2-binary" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "requests" },
     { name = "ruff" },
     { name = "uvicorn" },
@@ -222,8 +233,10 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.8" },
     { name = "pgserver", specifier = ">=0.1.4" },
+    { name = "pre-commit", specifier = ">=3.5" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "uvicorn", specifier = ">=0.29" },
@@ -248,6 +261,118 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/97/c52dc440c390b6cfa87be9432b141a956e2d56d9b9f5fc8bd71c5f471722/coverage-7.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:50913d4bf5ddafa6ca3693da5e4dd833dd1b772e0283c99ca7f7d287db67331a", size = 220539, upload-time = "2026-07-02T13:08:19.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/26/602de8c2aec7e2e3e99ebfb8e04ba65598f746275396eea5f6794ff4673f/coverage-7.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:359e141ccd33893ce3f1ad5525f8b96083003677c82182e5907d62d4ea5799fc", size = 221058, upload-time = "2026-07-02T13:08:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/13/ebab0743138891c1d646d61e247ec29639afcbb6c4e1905e6a0f0c75291a/coverage-7.15.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3200b6204935f928c64b2ca1f923ab8c1acb7c9de45ec61569711b34d25cccaf", size = 247797, upload-time = "2026-07-02T13:08:22.474Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/b6ffb9e042aa48dc4144a8a65529affaec8dca0685309353614a2a7386ad/coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:be616bf61346883b2cfdc5178669647e03531d81ab761a7e378558b7e8bcb628", size = 249626, upload-time = "2026-07-02T13:08:23.803Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/06/243ff05b652333d8e3d060c11223efc2723b19cacf6605e433fa686ab5d4/coverage-7.15.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc7bafc3fe1059463a8fdd97ca79972d6e2bf819d775c7d54991b5b1971201d6", size = 251493, upload-time = "2026-07-02T13:08:25.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2b/867faa17030a806114dae388b32a3fa929d8cd4bf39226fbc11f6e6bb705/coverage-7.15.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b713aa7fcf325a01d4184d848acb46fd84f78fdb0978470c636b23a06a753d91", size = 253406, upload-time = "2026-07-02T13:08:26.842Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c0/d789ce18f6605afc4895db75723424be2ef494282f77f61d8e5832923183/coverage-7.15.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e38e6fba2d56652fdfaf0231f8f78aeb805234a912de25dc291ee5cce5b8faa4", size = 248512, upload-time = "2026-07-02T13:08:28.398Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/b2673c30739f4a2e06649a0a38ad8b093c4d865462dc7bab0e9524a2c3b1/coverage-7.15.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:884499f42e382675be80770391983b90e0c0c774d87dbeeebf5f991cf6612b20", size = 249532, upload-time = "2026-07-02T13:08:29.731Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/acd79e9a41beabee92b623afe4f30b549916f48566271475f2907e752828/coverage-7.15.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:840481b12e083dbcbafab14794a8781a958edf327c8d3d70b4eee42f9b8253aa", size = 247537, upload-time = "2026-07-02T13:08:31.173Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d4/2d301c4d1b3238d7c88b70ab9d13fd53ed9505662a7ff1b46ba1e2e4e3c3/coverage-7.15.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:276646e9481703d09f854f3b2f018f24e19fd7049ae670a92570043eb97203b1", size = 251348, upload-time = "2026-07-02T13:08:32.63Z" },
+    { url = "https://files.pythonhosted.org/packages/35/bb/c67708b2bc00f32e12805ec23d5fa677a0a51652f449341a89f9d6b1b715/coverage-7.15.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4de4b4d3f5545aa6c60dc4efd9c63b5b5dcc3bf00fe83146b2bdfffb8f6613bd", size = 247806, upload-time = "2026-07-02T13:08:33.931Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6c/57c4f653c47a6e917748f8938e389e72fbcae44e3643cd906664f0477a13/coverage-7.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5c504097b2a89b1e85bc6070d920df77daec701337e3aeef2c17775a5dd0ca90", size = 248410, upload-time = "2026-07-02T13:08:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/94/bb083041aef828903668f134273f319f2bd49224962875359c52faa5497f/coverage-7.15.0-cp310-cp310-win32.whl", hash = "sha256:f6e80ed91f98316e86b9c137206b04b2bcfbffccbdff49bd2eb09dddb1cf14e0", size = 222588, upload-time = "2026-07-02T13:08:36.486Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/94/a09d8ee618956f626741b0734854bac4425a00e10c0565f5abca64e7e751/coverage-7.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3b3e22030f3f6f5e01a5ce69936552a5c0f6992b7698777377b99041961031f", size = 223214, upload-time = "2026-07-02T13:08:37.885Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/23/82e910835ef4b8391047025e1d53aa48d66029f444eb8b25373c849bf503/coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a", size = 220662, upload-time = "2026-07-02T13:08:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0d/c7b213dde2f1579de5231062b386d8413f79c11667eb58c39319b25991da/coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118", size = 221168, upload-time = "2026-07-02T13:08:40.471Z" },
+    { url = "https://files.pythonhosted.org/packages/33/77/d000aeedfac085088337b3c7becdad328474b1f8a9e4c9368a0c99605d68/coverage-7.15.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8773e15c23305b58882a4611fb9b2755977eae0dc2e515366a1b6c98866cc4c2", size = 251587, upload-time = "2026-07-02T13:08:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e0/86787c56b9df17afd370d5e293515dd4d9a107a561d13054873eefad8ecc/coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8", size = 253497, upload-time = "2026-07-02T13:08:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/02/181bc917359299c07dead6270f94e411151c8b60cec905c33499da69afe6/coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5", size = 255607, upload-time = "2026-07-02T13:08:44.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/35/ca5e7427699913da6788c4f910e73ab16c5f4b59ec5d3a999dce2a45112f/coverage-7.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:51aa20f6ae2788fd197747766edf4cd8234fd9423309b934257fa6b21a592723", size = 257563, upload-time = "2026-07-02T13:08:46.334Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4d/b8220bacc2fc3c4e9078e27c32e99fb411479a4718a72bdd00036a9891c8/coverage-7.15.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03d1f922757662eb7af586e77834792274cff776bc7b1d1a0b66a49ea9d84735", size = 251726, upload-time = "2026-07-02T13:08:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/2e145da1991d72189b9c3cf7eca05c716ee7080d099aaea6757cfc7df008/coverage-7.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a6d6acc9a7666245e6133dd15144ca038a85a9cd5026bb06d6bbae9e77440dc9", size = 253301, upload-time = "2026-07-02T13:08:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/72/28/d2c841d698bf762e481f08bd4839d370246b6d9b61dab085a7b20b201a08/coverage-7.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1ac2c4c27c7df851dc9a017c2d7de00b69147e84ba3d96f37a530b0b6fb51035", size = 251361, upload-time = "2026-07-02T13:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/55d9ffde994fba3897c0c783f77a7d053b0c18787f6892ed5b0aed73f469/coverage-7.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b761a1d504fd4bd1f20f418753964dca9f5862a511fc854dac58296b3b223671", size = 255129, upload-time = "2026-07-02T13:08:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c0/ecbf33b8c460ea2718aeb813e2df8140d0370e5f67261c31524ceb0a2a8d/coverage-7.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e43b045e11c16e897895758ae90e4a90cf99e93d58549e2f90c0e2272e155695", size = 251081, upload-time = "2026-07-02T13:08:54.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/de/fb87b4261f54448dd2b9504ef19a58be42cef0d9520595fbfe1219b15234/coverage-7.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:589b54513e901739f4b4582c705ce96b80c96f57641b1464607e2367a270e540", size = 251988, upload-time = "2026-07-02T13:08:55.726Z" },
+    { url = "https://files.pythonhosted.org/packages/df/27/3494d5f291b9a4cb868f73c11221a8bd2d5bd761a8f9acea61ff57128dd1/coverage-7.15.0-cp311-cp311-win32.whl", hash = "sha256:106781b8482749162d0b47056937ba0933508e5d9447f65a5e7d5c422f0d6bb4", size = 222754, upload-time = "2026-07-02T13:08:57.091Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ee/cd4847ebc9be6a9c0123d763645a6f1f3be6b8c58c962706368b79cbac07/coverage-7.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6", size = 223225, upload-time = "2026-07-02T13:08:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/57/37/5011581aa7f2be498b97dcc7c9902192442a42f4f9a748aeadb3d6506b42/coverage-7.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:309990eb5fb8014b9f67cb211f7fd41876ec8a88a88d3ae76de0ed1d611e3640", size = 222774, upload-time = "2026-07-02T13:09:00.074Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d", size = 220838, upload-time = "2026-07-02T13:09:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe", size = 221197, upload-time = "2026-07-02T13:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/17/99fa688541ae1d6e84543a0e544f83de0c944815b63e9e7b1ed411d15036/coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c", size = 252705, upload-time = "2026-07-02T13:09:05.059Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4", size = 255441, upload-time = "2026-07-02T13:09:06.559Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5", size = 256556, upload-time = "2026-07-02T13:09:08.197Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/d3fa48489c15ecdec1ba48fd61f68798555dddd2f6716f9ad42adeb1a2a9/coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01", size = 258815, upload-time = "2026-07-02T13:09:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/2d40ddd110462c6a2769677cf7f1c119a52b45f568978fc6c98e4cc0dd0f/coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4", size = 253117, upload-time = "2026-07-02T13:09:11.212Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/310782f0d7c3cb2b5ac05ba8d205fe91f24a36f6bf3256098f1782181c38/coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796", size = 254475, upload-time = "2026-07-02T13:09:13.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/702da6c275f8ae6ade423d2877243122932c9b27f5403003b9ef8c927d12/coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382", size = 252619, upload-time = "2026-07-02T13:09:14.699Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/c5b15a7e5ecba4e56218d772d99fe80a63e63f8d11f12783723a6005ab45/coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c", size = 256689, upload-time = "2026-07-02T13:09:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2f/c8b07559b57701230c61b23a953858c052890c12ef568d81780c6c46e92e/coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766", size = 252189, upload-time = "2026-07-02T13:09:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/80/6d2f049dd3fd3dbfd60b62ba6b2162a04009e2c002ce70b24cf3878dec7a/coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da", size = 254059, upload-time = "2026-07-02T13:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/92/b0287a2c42031d25c628f815f89a3cd9f8268ee78bb1252c9356cda1c689/coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77", size = 222893, upload-time = "2026-07-02T13:09:20.812Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6", size = 223429, upload-time = "2026-07-02T13:09:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/98/6e878f0b571d32684ef3f38d7c03db241ca5b82a5da8a5391596a8f209c4/coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b", size = 222810, upload-time = "2026-07-02T13:09:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9c/1e3ca54f72a3185ece06c58d871099898c48f0ed6430d17b6ab75f0d180a/coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324", size = 220906, upload-time = "2026-07-02T13:09:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/09/37/f718613d83b274880382f6b67e78f3802549ae39b0b3e65ae5b5974df56e/coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8", size = 221239, upload-time = "2026-07-02T13:09:53.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/22bae91e0b75445f68d365c7643ed0aa4880bbf77450ee74ca65bdae53a7/coverage-7.15.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:769e8ece11a596315ebf5aa7ec383aeeed016c091d2bf6363ffb996d41529092", size = 252286, upload-time = "2026-07-02T13:09:54.996Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/bec5e32aa508615d9d7a2790effb25fb4dc28606e995816afe400b25ece3/coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502", size = 254789, upload-time = "2026-07-02T13:09:56.678Z" },
+    { url = "https://files.pythonhosted.org/packages/17/29/0e865435b4354e4a7c03b1b7920046d31d0a273d55decefea27e011cb9bf/coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2", size = 256135, upload-time = "2026-07-02T13:09:58.343Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/33a870b58a13325d62fc0a6c8f01fa0ff667cef60c7498e2382a147dfa18/coverage-7.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9887bb428fe2d4cd4bee89bac1a6c9932f484afd5b36fbd4ff6ea5f825bb1f5e", size = 258449, upload-time = "2026-07-02T13:10:00.057Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7b/6fffe596bf3ddba8462758d02c5dad730fd91055a6634aa2e4226229181a/coverage-7.15.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0bfc0be1f702042207a93a00523b1065ee1fe951e96edf311581c0bbc2e34888", size = 252313, upload-time = "2026-07-02T13:10:01.946Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1b/11468dd6c1676ab831a70cb9a8d4e198e8607fa0b7220ab918b73fe9bfbd/coverage-7.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f64627d55def5a43282d70e08396672692f77e4da610a5bb8bb4060b432b6859", size = 254142, upload-time = "2026-07-02T13:10:04.065Z" },
+    { url = "https://files.pythonhosted.org/packages/79/41/29328e21d16b1b95092c30dd700e08cf915bd3734f836df8f3bdb0e8fa9f/coverage-7.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2c6f0fa473003905c6d5bac328ee4eba9fbea654f15bc24b8a3274b23363fa99", size = 252108, upload-time = "2026-07-02T13:10:06.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/05ccfb990439655b35afbfd8e0d13fe66677565a7d4eb38c3f5ef2635e1c/coverage-7.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2bcf9afaf064172c6ec3c58a325a9957ad1178c05dd934e25f253321776e0676", size = 256385, upload-time = "2026-07-02T13:10:08.141Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/486828a3d2695ea7a2609f17ff572f6b01905e608379440a11da4b8dffbe/coverage-7.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:baf06bc987115d6fb938d403f7eab684a057766c490367999a2b71a6883110c6", size = 251923, upload-time = "2026-07-02T13:10:10.179Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c7/03582b6715f078e5e558354c87616d945b9894cda2dace8e4009b17035e4/coverage-7.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0405f2ff97b1c4c0e782cb32e02f32369bcf2e6b618b591d67e1ea754575dfe", size = 253580, upload-time = "2026-07-02T13:10:12.052Z" },
+    { url = "https://files.pythonhosted.org/packages/db/dc/9e578bbaf2ecb4959a81b7e7601ad8cca772cba2892e8d144cb749b4a71a/coverage-7.15.0-cp314-cp314-win32.whl", hash = "sha256:ab282853ed5fbd64bbb162f19cb8fcb7087187508a6374b4f9c34ec1577c4e8f", size = 223107, upload-time = "2026-07-02T13:10:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3e/c8c3b75d8dbe0e35f7b0cc3ff5e949fc59500f70b21d0398813f66740664/coverage-7.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663", size = 223597, upload-time = "2026-07-02T13:10:15.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/bc/3cbc9fb036eb388519bccd521f783499c39b64256013fbc362782f196fe1/coverage-7.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:346771144d34f7fa84ec28386f78e0f31653f33cf35e19d253d5b35f9e8201da", size = 223020, upload-time = "2026-07-02T13:10:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/28/00/199c4a8d656dff63102577a056c0fce2ff6a79e40adac092fc986c49cbf1/coverage-7.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d34a010905fb6401324ba016b5da03d574967f7b21ce48ea41e66f0f1f95f641", size = 221638, upload-time = "2026-07-02T13:10:19.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8e/9d0092c96a3d3a26951ecc7020826aa57bcb1b119ca81acbba996884ab13/coverage-7.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bb25d825d885ca8036795dacfc3924d33091fc76d71ebc99420c6b79e77d96fa", size = 221903, upload-time = "2026-07-02T13:10:21.514Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/c0ca3028f42c9a08e51feb4561ef1192e5de99797cd1db5b04590c215bda/coverage-7.15.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:94c9686bfe8a9a6810297aecbd99beaa3445f9e8dc2f80b1382cca0d86b64461", size = 263267, upload-time = "2026-07-02T13:10:23.261Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/aa/a375e3846e5d3c013dc600b2a3231089055c73d77f5393dd2192a8d64da6/coverage-7.15.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9bd671c25f9d85f09d7ec481d0e43d5139f486c06a37139847a7ce569788af72", size = 265390, upload-time = "2026-07-02T13:10:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e1/5783cdabb797305e1c9e4809fea496d31834c51fa772514f73dc148bcfc9/coverage-7.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:110cbdf8d2e216577312cf06ccf85539c0e5a5420ef747e4a4719b5e483c88cd", size = 267811, upload-time = "2026-07-02T13:10:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/85/31/96d8bbf58b8e9193bc8389574a91a0db48355ee98feb66aa6bf8d1b32eea/coverage-7.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c5d4619214f1d9993e7b00a8600d14614b7e9d84e89507460b126aa5e6559e5", size = 268928, upload-time = "2026-07-02T13:10:29.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7a/5294567e811a1cb7eda93140c628fa050d66189da28da320f93d1d815c73/coverage-7.15.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:781a704516e2d8346fbbd5be6c6f3412dd824785146528b3a01816f26c081007", size = 262378, upload-time = "2026-07-02T13:10:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3f/3f48538421f899f28946f90a3d272136a4686e1abf461cc9249a783ee0f3/coverage-7.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd4a1b44bcb65ee29e947ac92bbee04956df3a6bfc6143641bb6cae7ede00fc9", size = 265263, upload-time = "2026-07-02T13:10:32.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d3/092df15efcab8a9c1467ee960eb8019bbad3f9300d115d89ea6195f369ff/coverage-7.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0e4950c9d6d3e39c64c991814ff315e2d0b9cb8152363594212c9e55208c0a8f", size = 262866, upload-time = "2026-07-02T13:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ab/0254d2b88665efb2c57ad368cc77ab5de3435bd8d5add4729c1b0e79431e/coverage-7.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fe9c87ff42e5472d80d21704972e1f96e104a0a599d77c5e35db5a3c562e2571", size = 266599, upload-time = "2026-07-02T13:10:37.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/1cfa4023e489ce6fbc7be4a5d442dbc375edb4f4fda39a352cedb53263c2/coverage-7.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f00d5ae1dd2fe13fb8186e3e7d37bcbd8b25c0d764ff7d1b32cef9be058510a8", size = 261714, upload-time = "2026-07-02T13:10:38.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/fee5c8665656be63f497418d410484637c438172568688e8ac92e06574e7/coverage-7.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:363ab38cc78b615f11c9cac3cf1d7eef950c18b9fdedfb9066f59461dcf84d68", size = 264025, upload-time = "2026-07-02T13:10:40.789Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/99/63005db722f91edc81abc16302f9cc2f6228c1679e46e15be9ae144b14d0/coverage-7.15.0-cp314-cp314t-win32.whl", hash = "sha256:54fd9c53a5fafff509195f1b6a3f9be615d8e8362a3629ff1de23d270c03c86b", size = 223413, upload-time = "2026-07-02T13:10:42.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/2bc6181c4fb06f1a6b981eb85330cc57bfad7e3f710fc9c9d350013ba228/coverage-7.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:87b47553097ba185ed964866078e7e63adea9f5f51b5f39691c34f30afd21080", size = 224245, upload-time = "2026-07-02T13:10:44.47Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/4d959bf9cc45d0cfed2f4d35cafcab978cdb6ea02eb5100009cd740632a3/coverage-7.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aeefb2dd178fe7eee79f0ad25d75855cb35ee9ed472db2c5ea06f5b4fd00cec5", size = 223558, upload-time = "2026-07-02T13:10:46.368Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -285,6 +410,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/18/7881a99ba5244bfc82f06017316ffe93217dbbbcfa52b887caa1d4f2a6d3/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8", size = 25087, upload-time = "2025-08-11T10:19:37.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7", size = 18702, upload-time = "2025-08-11T10:19:35.716Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -372,6 +506,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -549,6 +692,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -700,6 +852,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -949,6 +1117,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -1228,6 +1423,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Finishes the remaining **Phase 0** tooling items and fixes a checkmate-detection correctness bug. Three focused commits.

## Bug fix — diagonal blocking-square math (`bd55a13`)
`check_for_mate` computed the squares between a checking slider and the king incorrectly for **diagonal** checks: it used `king_square.j` where it meant `.i`, and the diagonal loops were off by one (started on the checker's own square, stopped one short of the king). A diagonal check that could be **blocked by interposing a piece** was misreported as checkmate.

Replaced the hand-rolled rank/file/diagonal cases with one `Board._squares_between(a, b)` helper (correct for ranks, files, and diagonals). Three regression tests: blockable diagonal check (not mate), genuine long-range diagonal mate (still mate), diagonal check answered by a capture (not mate).

## Phase 0 tooling (`876792e`)
- **`integration` marker**: registered and applied to `tests/integration/`; `pytest -m "not integration"` now runs unit-only (**69 unit / 16 integration**).
- **Coverage gate**: added `pytest-cov` + coverage config; new CI `coverage` job runs the full suite with `--cov-fail-under=75` (currently **~78%**).
- **pre-commit**: `.pre-commit-config.yaml` running `ruff-check --fix` + `ruff-format`, pinned to the ruff version in use; `pre-commit` added to the dev group (hooks verified passing locally).
- Wired `ruff format --check` into the CI lint job.

## `ruff format` reflow (`ae9ab23`)
Mechanical `ruff format` across the codebase (26 files, no behavior change) so the new format check passes.

---

**Verification (mirrors CI):** `ruff check` ✓ · `ruff format --check` ✓ · `mypy` ✓ · unit matrix (`--no-dev`) 69 ✓ · full suite + coverage gate **85 passed, 78.36% ≥ 75%** ✓ · `uv build` ✓.

This completes Phase 0. Remaining roadmap: Phase 3 (`[BREAK]` API/human-interaction changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)