### PR TITLE
Phase 3: public API redesign (accessors, factories, versioned + authed server)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,18 +49,20 @@ Package data (`data/*.sql`, `data/*.ttf`, `data/img/*.png`) is declared under `[
 
 ## Three-tier architecture
 
-The single public export is `Game` (`src/chesssnake/__init__.py` → `from .remote.game import Game`). It is an `engine.Game` subclass that is **local by default** and **remote when asked**:
+The public exports are `Game`, the challenge helpers (`challenge`, `challenge_exists`, `delete_challenge`), and the enums (`Color`, `GameStatus`, `PieceType`) — see `src/chesssnake/__init__.py`. `Game` is an `engine.Game` subclass built via **factory methods** (not a flag-laden constructor):
 
-- `Game(white_name=..., black_name=...)` — pure in-memory game. No network, no `requests`/psycopg2 imported. Identical to the raw engine.
-- `Game(white_id, black_id, group_id, remote=True, api_url=...)` — on construct it `POST`s to the api-endpoint to get-or-create the game and rebuilds the board from the returned state. `move`/`draw_*` still run the engine locally; with `auto_sync=True` they push state to the API after each call (or call `game.sync()` yourself). `api_url` falls back to `CHESSSNAKE_API_URL`.
+- `Game.local(white_name=..., black_name=...)` — pure in-memory game. No network, no `requests`/psycopg2 imported. Identical to the raw engine.
+- `Game.remote(white_id, black_id, group_id=..., api_url=..., api_key=..., auto_sync=True)` — `POST`s to the api-endpoint to get-or-create the game and rebuilds the board from the returned state. `move`/`draw_*` still run the engine locally; with `auto_sync=True` (the default) they push state to the API after each call. It's also a context manager that `sync()`s on clean exit. `api_url` falls back to `CHESSSNAKE_API_URL`.
+
+Gameplay state is read through intention-revealing accessors on `Game`: `to_move` (Color), `is_over` (bool), `result` (GameStatus), `winner` (Color|None), `draw_offered_by` (Color|None). `move()` returns the `Move` played (rendering is separate: `render()` / `save(path)`).
 
 The three tiers and where they live:
 
-1. **Client** (`src/chesssnake/remote/`) — `Game`/`Challenge` (`game.py`) run the engine locally; `ApiClient` (`client.py`) is a thin `requests`-style wrapper. `requests` is imported lazily, only on the `remote=True` path, so local games and the engine stay dependency-free.
-2. **Server** (`src/chesssnake/api/server.py`) — a FastAPI `app` exposing a thin persistence API (get-or-create, update, draw patch/clear, delete, current/exists, challenges, `/health`). It **never imports the `engine`** — it only moves serialized strings/ids in and out of Postgres. Domain errors are mapped to JSON `{error_type, detail}` with status codes (id→422, challenge→409, sql→500); the client re-raises the matching `GameError` type.
+1. **Client** (`src/chesssnake/remote/`) — `Game` + the challenge functions (`game.py`) run the engine locally; `ApiClient` (`client.py`) is a thin `requests`-style wrapper (talks to the `/v1` routes, sends an optional `X-API-Key`). `requests` is imported lazily, only on the remote path, so local games and the engine stay dependency-free.
+2. **Server** (`src/chesssnake/api/server.py`) — a FastAPI `app`. `/health` is unversioned/open; all game+challenge routes live on a `/v1` `APIRouter` gated by an optional API-key dependency (`require_api_key`, active only when `CHESSSNAKE_API_KEY` is set). It **never imports the `engine`** — it only moves serialized strings/ids in and out of Postgres. Domain errors are mapped to JSON `{error_type, detail}` with status codes (id→422, challenge→409, sql→500); the client re-raises the matching `GameError` type.
 3. **Database** (`src/chesssnake/db/`) — the SQL, behind a common interface (`db/__init__.py` re-exports the operations so callers depend on `chesssnake.db`, leaving room for a future `db/sqlite.py`). `db/postgres.py` holds the pure query functions the server calls (the PostgreSQL backend); `db/sql.py` the pool + `execute_psql`; `db/errors.py` the `GameError` exception types (now `Exception`-based so FastAPI can catch them); `data/init.sql` the schema.
 
-`src/chesssnake/cli.py` is the `chesssnake` console-script entry point (`api-endpoint`, `init-db` subcommands). `src/chesssnake/assets.py` (`asset_path`) centralizes packaged-data lookups.
+The wire payload is defined once as `src/chesssnake/dto.py`'s `GameState` (a stdlib dataclass, so the client needs no pydantic) and used by both the client and the server. `src/chesssnake/cli.py` is the `chesssnake` console-script entry point (`api-endpoint`, `init-db` subcommands). `src/chesssnake/assets.py` (`asset_path`) centralizes packaged-data lookups.
 
 When changing **gameplay** behavior, edit `engine` — every tier inherits it. When changing **persistence**, edit `db/postgres.py` (SQL) and mirror the endpoint in `api/server.py` + the method in `remote/client.py`.
 
@@ -82,14 +84,14 @@ When changing **gameplay** behavior, edit `engine` — every tier inherits it. W
 
 ### `remote/` — the client (tier 1)
 
-- `game.py` — `Game(BaseGame)` (local-or-remote, described above) plus `Challenge` (pending-challenge matchmaking; static methods that hit the challenge endpoints).
-  - Games are keyed by the composite `(group_id, white_id, black_id)` — all BIGINTs. `POST /games` does an upsert-then-select so a `Game` either loads the existing row or creates a fresh one.
-  - Board (de)serialization lives on the client: `Board.disassemble_board()` → a `;`-delimited string of `<type><color>`/`--` tokens plus a 6-char `moved` castling-rights string, sent to the API; `_board_from_state()` reverses it with `Board.assemble_board()` (+ `get_coords` for the en-passant square). These must stay in sync.
-- `client.py` — `ApiClient(base_url, session=None)`. `session` defaults to a `requests.Session()` but can be **injected** (the tests pass a FastAPI `TestClient`, which is request-compatible — this is how the integration tests drive the app in-process). Non-2xx → re-raises the mapped `GameError` type.
+- `game.py` — `Game(BaseGame)` (built via `Game.local()`/`Game.remote()`, described above) plus module-level challenge functions `challenge`/`challenge_exists`/`delete_challenge` (pending-challenge matchmaking; each takes `api_url=`/`api_key=`/`client=`). The low-level `Game.__init__(*args, client=None, auto_sync=False, **kwargs)` is internal — use the factories.
+  - Games are keyed by the composite `(group_id, white_id, black_id)` — all BIGINTs. `POST /v1/games` does an upsert-then-select so a game either loads the existing row or creates a fresh one.
+  - Board (de)serialization lives on the client, exchanged as a `dto.GameState`: `Board.disassemble_board()` → a `;`-delimited string of `<type><color>`/`--` tokens plus a 6-char `moved` castling-rights string; `_board_from_state()` reverses it with `Board.assemble_board()` (+ `get_coords` for the en-passant square). These must stay in sync.
+- `client.py` — `ApiClient(base_url, session=None, api_key=None)`. Prefixes every request with `/v1` and (if set) an `X-API-Key` header. `session` defaults to a `requests.Session()` but can be **injected** (the tests pass a FastAPI `TestClient`, which is request-compatible — this is how the integration tests drive the app in-process). `get_or_create_game` returns a `dto.GameState`; `update_game` takes one. Non-2xx → re-raises the mapped `GameError` type.
 
 ### `api/` — the server (tier 2)
 
-- `server.py` — the FastAPI `app`. Pydantic models validate bodies; a `lifespan` handler initializes the connection pool from env creds (and runs schema init if `CHESSSNAKE_INIT_DB` is set). Routes delegate to the `db` layer (`from ..db import postgres as ops`).
+- `server.py` — the FastAPI `app`. `/health` is unversioned and open; game+challenge routes live on a `/v1` `APIRouter` with a `require_api_key` dependency (enforced only when `CHESSSNAKE_API_KEY` is set, checked per-request). The game-state body/response is the shared `dto.GameState` dataclass; small request bodies (`GameCreate`/`DrawUpdate`/`ChallengeBody`) stay pydantic. A `lifespan` handler initializes the connection pool from env creds (and runs schema init if `CHESSSNAKE_INIT_DB` is set). Routes delegate to the `db` layer (`from ..db import postgres as ops`).
 
 ### `db/` — the database layer (tier 3)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ pip install chesssnake[api]
 ```
 
 ## Usage
-This library's API is focused around a `Game` object. Every `Game` object represents a game between two players
+This library's API is focused around a `Game` object. Every `Game` object represents a game between two players.
+
+Build games with the factory methods: `Game.local(...)` for an in-memory game, or `Game.remote(...)` for one persisted through an api-endpoint (see below).
 
 ### Basic usage
 
@@ -56,25 +58,35 @@ A simple example:
 ```Python3
 from chesssnake import Game
 
-# Initialize a new game
-game = Game(white_name="Bob", black_name="Phil")
+# Initialize a new local game
+game = Game.local(white_name="Bob", black_name="Phil")
 
-# Make moves
-game.move('e4') # Bob's move
-game.move('e5') # Phil's move
+# Make moves — move() returns the Move that was played
+game.move('e4')  # Bob's move
+game.move('e5')  # Phil's move
 
 # Print the board
 print(game)
 
-# make the move, return a PIL image object, and show the board in png format
-game.move('Nc3', img=True).show()
-
-# save the board as a png
-game.save('/path/to/your/image1.png')
-
-# make the move, and save the board as a png
-game.move('Bc5', save='/path/to/your/image2.png')
+# Rendering is separate from moving:
+game.move('Nc3')
+game.render().show()           # a PIL image of the board (last move highlighted)
+game.save('/path/to/img.png')  # or write it straight to disk
 ```
+
+### Inspecting game state
+
+Use the intention-revealing accessors instead of raw internals:
+
+```Python3
+game.to_move          # Color.WHITE or Color.BLACK — whose turn it is
+game.is_over          # True once the game has ended
+game.result           # a GameStatus: IN_PLAY, CHECKMATE, or DRAW
+game.winner           # the winning Color on checkmate, else None
+game.draw_offered_by  # the Color with an open draw offer, else None
+```
+
+`Color`, `GameStatus`, and `PieceType` are importable from `chesssnake`.
 
 ### Persisting games through the api-endpoint
 
@@ -97,34 +109,38 @@ Then start the server (the `--init-db` flag creates the schema on first run):
 chesssnake api-endpoint --host 0.0.0.0 --port 8000 --init-db
 ```
 
-Interactive API docs are served at `http://<host>:8000/docs`.
+Interactive API docs are served at `http://<host>:8000/docs`. The HTTP routes are versioned under `/v1`; the client handles that for you. To require authentication, set `CHESSSNAKE_API_KEY` on the server and pass the same `api_key=` to `Game.remote(...)`.
 
-**2. Connect game clients.** Any number of clients can share the one endpoint. Set `remote=True` and give the endpoint URL via the `api_url` argument or the `CHESSSNAKE_API_URL` environment variable:
+**2. Connect game clients.** Any number of clients can share the one endpoint. Use `Game.remote(...)`, giving the endpoint URL via the `api_url` argument or the `CHESSSNAKE_API_URL` environment variable:
 
 ```Python3
 from chesssnake import Game
 
 # If a game already exists for these ids it is loaded; otherwise a new one is created.
 # Games are unique per (white_id, black_id, group_id) — all BIGINTs.
-game = Game(
-  white_id=123,
-  black_id=456,
+game = Game.remote(
+  123,            # white_id
+  456,            # black_id
   group_id=789,
   white_name="Bob",
   black_name="Phil",
-  remote=True,
   api_url="http://localhost:8000",
+  # api_key="...",  # if the server requires one
 )
 
 game.move('e4')  # Bob's move
-game.move('e5')  # Phil's move
-
-# push the new state to the api-endpoint
-game.sync()
+game.move('e5')  # Phil's move — each move is synced automatically (auto_sync defaults to True)
 ```
 
-Pass `auto_sync=True` instead of calling `sync()` to have every move and draw action pushed to the endpoint automatically.
+Remote games sync after every move and draw action by default. Pass `auto_sync=False` to batch changes and push them yourself with `game.sync()`. A remote game is also a context manager that syncs on exit, so a forgotten `sync()` can't silently drop moves:
 
-Without `remote=True`, a `Game` is a purely local, in-memory game (no server or database required).
+```Python3
+with Game.remote(123, 456, group_id=789, api_url="http://localhost:8000", auto_sync=False) as game:
+    game.move('e4')
+    game.move('e5')
+# state is pushed here, on exit
+```
+
+Matchmaking helpers (`challenge`, `challenge_exists`, `delete_challenge`) are also importable from `chesssnake`.
 
 For more information, see the docs (coming soon)

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,20 +1,22 @@
 from chesssnake import Game
 
-# Initialize a new game
-game = Game(white_name="Bob", black_name="Phil")
+# Initialize a new local game
+game = Game.local(white_name="Bob", black_name="Phil")
 
-# Make moves
+# Make moves (move() returns the Move that was played)
 game.move("e4")  # Bob's move
 game.move("e5")  # Phil's move
 
 # Print the board
 print(game)
 
-# make the move, and show the board in png format
-game.move("Nc3", img=True).show()
+# Rendering is separate from moving:
+game.move("Nc3")
+game.render().show()  # show the current board as an image
 
-# save the board as a png
+# save the board as a png (highlights the last move)
 game.save("/path/to/your/image1.png")
 
-# make the move, and save the board as a png
-game.move("Bc5", save="/path/to/your/image2.png")
+# inspect game state through intention-revealing accessors
+print("to move:", game.to_move)
+print("game over?", game.is_over)

--- a/src/chesssnake/__init__.py
+++ b/src/chesssnake/__init__.py
@@ -1,3 +1,12 @@
-from .remote.game import Game
+from .engine.enums import Color, GameStatus, PieceType
+from .remote.game import Game, challenge, challenge_exists, delete_challenge
 
-__all__ = ["Game"]
+__all__ = [
+    "Game",
+    "challenge",
+    "challenge_exists",
+    "delete_challenge",
+    "Color",
+    "GameStatus",
+    "PieceType",
+]

--- a/src/chesssnake/api/server.py
+++ b/src/chesssnake/api/server.py
@@ -9,17 +9,24 @@ Run it with ``chesssnake api-endpoint`` (see ``chesssnake.cli``), or point an AS
 server at ``chesssnake.api.server:app``. Database credentials are read from the
 ``CHESSDB_*`` environment variables on startup; set ``CHESSSNAKE_INIT_DB=1`` to
 also initialize the schema on startup.
+
+Game/challenge routes are versioned under ``/v1``. Set ``CHESSSNAKE_API_KEY`` to
+require an ``X-API-Key`` header on those routes (``/health`` stays open).
 """
 
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from ..db import errors, sql
 from ..db import postgres as ops
+from ..dto import GameState
+
+# Header carrying the optional API key.
+API_KEY_HEADER = "X-API-Key"
 
 
 @asynccontextmanager
@@ -35,7 +42,23 @@ async def lifespan(_app):
 app = FastAPI(title="chesssnake api-endpoint", lifespan=lifespan)
 
 
+# --- Auth ------------------------------------------------------------------
+
+
+async def require_api_key(x_api_key: str | None = Header(default=None, alias=API_KEY_HEADER)):
+    """Require a matching ``X-API-Key`` header iff ``CHESSSNAKE_API_KEY`` is set.
+
+    Read per-request (not cached) so the key can be configured at deploy time and
+    toggled without restarting. When unset, authentication is disabled.
+    """
+    configured = os.getenv("CHESSSNAKE_API_KEY")
+    if configured and x_api_key != configured:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
 # --- Schemas ---------------------------------------------------------------
+# The game-state wire shape lives in chesssnake.dto.GameState (shared with the
+# client). The small request bodies below are server-only.
 
 
 class GameCreate(BaseModel):
@@ -44,17 +67,6 @@ class GameCreate(BaseModel):
     black_id: int = 1
     white_name: str = ""
     black_name: str = ""
-
-
-class GameState(BaseModel):
-    board: str
-    turn: int
-    pawnmove: str | None = None
-    draw: int | None = None
-    moved: str
-    status: int
-    wname: str | None = None
-    bname: str | None = None
 
 
 class DrawUpdate(BaseModel):
@@ -66,20 +78,6 @@ class ChallengeBody(BaseModel):
     group_id: int = 0
     challenger: int
     challenged: int
-
-
-def _state(row):
-    """Project a raw Games row into the client-facing state payload."""
-    return {
-        "board": row["board"],
-        "turn": int(row["turn"]),
-        "pawnmove": row["pawnmove"].strip() if row["pawnmove"] is not None else None,
-        "draw": int(row["draw"]) if row["draw"] is not None else None,
-        "moved": row["moved"],
-        "status": int(row["status"]),
-        "wname": row["wname"],
-        "bname": row["bname"],
-    }
 
 
 # --- Exception handlers ----------------------------------------------------
@@ -116,18 +114,23 @@ async def _handle_game_error(_request, exc):
 # --- Routes ----------------------------------------------------------------
 
 
+# /health is unversioned and unauthenticated (for liveness probes).
 @app.get("/health")
 async def health():
     return {"status": "ok"}
 
 
-@app.post("/games")
+# Everything else is versioned under /v1 and gated by the (optional) API key.
+v1 = APIRouter(prefix="/v1", dependencies=[Depends(require_api_key)])
+
+
+@v1.post("/games", response_model=GameState)
 async def create_game(body: GameCreate):
     row = ops.game_get_or_create(body.group_id, body.white_id, body.black_id, body.white_name, body.black_name)
-    return _state(row)
+    return GameState.from_row(row)
 
 
-@app.put("/games/{group_id}/{white_id}/{black_id}")
+@v1.put("/games/{group_id}/{white_id}/{black_id}")
 async def update_game(group_id: int, white_id: int, black_id: int, state: GameState):
     ops.game_update(
         group_id,
@@ -145,46 +148,49 @@ async def update_game(group_id: int, white_id: int, black_id: int, state: GameSt
     return {"status": "ok"}
 
 
-@app.patch("/games/{group_id}/{white_id}/{black_id}/draw")
+@v1.patch("/games/{group_id}/{white_id}/{black_id}/draw")
 async def patch_draw(group_id: int, white_id: int, black_id: int, body: DrawUpdate):
     ops.game_update_draw(group_id, white_id, black_id, body.draw, body.status)
     return {"status": "ok"}
 
 
-@app.delete("/games/{group_id}/{white_id}/{black_id}/draw")
+@v1.delete("/games/{group_id}/{white_id}/{black_id}/draw")
 async def clear_draw(group_id: int, white_id: int, black_id: int):
     ops.game_clear_draw(group_id, white_id, black_id)
     return {"status": "ok"}
 
 
-@app.delete("/games/{group_id}/{white_id}/{black_id}")
+@v1.delete("/games/{group_id}/{white_id}/{black_id}")
 async def delete_game(group_id: int, white_id: int, black_id: int):
     ops.game_delete(group_id, white_id, black_id)
     return {"status": "ok"}
 
 
-@app.get("/games")
+@v1.get("/games")
 async def list_current_games(player_id: int, group_id: int = 0):
     return {"opponents": ops.current_games(player_id, group_id)}
 
 
-@app.get("/games/{group_id}/exists")
+@v1.get("/games/{group_id}/exists")
 async def game_exists(group_id: int, player1: int, player2: int):
     return {"game": ops.game_exists(player1, player2, group_id)}
 
 
-@app.post("/challenges")
+@v1.post("/challenges")
 async def post_challenge(body: ChallengeBody):
     accepted = ops.challenge(body.challenger, body.challenged, body.group_id)
     return {"accepted": accepted}
 
 
-@app.get("/challenges/{group_id}/exists")
+@v1.get("/challenges/{group_id}/exists")
 async def challenge_exists(group_id: int, player1: int, player2: int):
     return {"challenge": ops.challenge_exists(player1, player2, group_id)}
 
 
-@app.delete("/challenges")
+@v1.delete("/challenges")
 async def delete_challenge(body: ChallengeBody):
     ops.challenge_delete(body.challenger, body.challenged, body.group_id)
     return {"status": "ok"}
+
+
+app.include_router(v1)

--- a/src/chesssnake/dto.py
+++ b/src/chesssnake/dto.py
@@ -1,0 +1,45 @@
+"""The wire payload shared by the client and the api-endpoint.
+
+``GameState`` is the single definition of the serialized game-state shape that
+crosses the network. It is a stdlib dataclass (no third-party dependency), so the
+client can use it without pulling in pydantic; FastAPI accepts it directly as a
+request/response model on the server side.
+
+Values are primitives on the wire: ``turn``/``draw`` are ints (0/1) or ``None``,
+``status`` is an int. The engine-side enum conversions happen in the client.
+"""
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class GameState:
+    """Serialized state of a single game, exchanged between client and server."""
+
+    board: str
+    turn: int
+    moved: str
+    status: int
+    pawnmove: str | None = None
+    draw: int | None = None
+    wname: str | None = None
+    bname: str | None = None
+
+    def to_dict(self) -> dict:
+        """Return the payload as a plain JSON-serializable dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_row(cls, row) -> "GameState":
+        """Build a ``GameState`` from a raw ``Games`` database row (dict-like)."""
+        return cls(
+            board=row["board"],
+            turn=int(row["turn"]),
+            moved=row["moved"],
+            status=int(row["status"]),
+            # the pawnmove column is CHAR(2)-padded; trim it back to notation
+            pawnmove=row["pawnmove"].strip() if row["pawnmove"] is not None else None,
+            draw=int(row["draw"]) if row["draw"] is not None else None,
+            wname=row["wname"],
+            bname=row["bname"],
+        )

--- a/src/chesssnake/engine/game.py
+++ b/src/chesssnake/engine/game.py
@@ -26,10 +26,19 @@ class Game:
     :ivar board: The chess board used in the game, represented as a `Board` object.
     :type board: Board
     :ivar turn: Whose turn it is, as a :class:`~chesssnake.engine.enums.Color`.
+        Prefer the :attr:`to_move` accessor in user code.
     :type turn: Color
     :ivar draw: Which color has an open draw offer (a
         :class:`~chesssnake.engine.enums.Color`), or ``None`` if none is active.
+        Prefer the :attr:`draw_offered_by` accessor in user code.
     :type draw: Color or None
+    :ivar last_move: The most recent :class:`~chesssnake.engine.move.Move`, or
+        ``None`` before any move. Used to highlight the board on :meth:`render`.
+    :type last_move: Move or None
+
+    Intention-revealing accessors (prefer these over the raw ints/enums above):
+    :attr:`is_over`, :attr:`result`, :attr:`winner`, :attr:`to_move`,
+    :attr:`draw_offered_by`.
     """
 
     def __init__(
@@ -68,6 +77,7 @@ class Game:
         self.board = Board() if board is None else board
         self.turn = Color(turn)
         self.draw: Color | None = Color(draw) if draw is not None else None
+        self.last_move: Move | None = None
 
     def __str__(self):
         """
@@ -77,6 +87,36 @@ class Game:
         :rtype: str
         """
         return str(self.board)
+
+    # --- state accessors ---------------------------------------------------
+
+    @property
+    def to_move(self) -> Color:
+        """The :class:`Color` whose turn it is to move."""
+        return self.turn
+
+    @property
+    def is_over(self) -> bool:
+        """``True`` if the game has ended (by checkmate or draw)."""
+        return self.board.status != GameStatus.IN_PLAY
+
+    @property
+    def result(self) -> GameStatus:
+        """The current :class:`GameStatus` (``IN_PLAY``, ``CHECKMATE``, or ``DRAW``)."""
+        return self.board.status
+
+    @property
+    def winner(self) -> "Color | None":
+        """The winning :class:`Color` on checkmate, or ``None`` if drawn/ongoing."""
+        if self.board.status == GameStatus.CHECKMATE:
+            # the mating side is the one that just moved — the opposite of to_move
+            return self.turn.opponent
+        return None
+
+    @property
+    def draw_offered_by(self) -> "Color | None":
+        """The :class:`Color` with an open draw offer, or ``None`` if there is none."""
+        return self.draw
 
     def is_players_turn(self, player_id: int) -> bool:
         """
@@ -92,21 +132,17 @@ class Game:
         else:
             return False
 
-    def move(self, move: str, img: bool = False, save: "str | None" = None):
+    def move(self, move: str) -> Move:
         """
         Executes a chess move if it is the active player's turn.
 
-        This method validates the move, applies it to the board, and changes the turn to the other player.
-        Optionally, it can generate a visual representation of the board as an image or save it as a PNG file.
+        Validates the move, applies it to the board, and passes the turn to the
+        other player. Rendering is separate — use :meth:`render` or :meth:`save`.
 
         :param move: The move to execute, in standard chess notation (e.g., "e4").
         :type move: str
-        :param img: If `True`, returns a `PIL.Image` object representing the board. Default is `False`.
-        :type img: bool
-        :param save: File path to save the board image as a PNG. If provided, it implies `img=True`.
-        :type save: str
-        :return: None or a `PIL.Image` object if `img=True` or `save` is specified.
-        :rtype: None or PIL.Image
+        :return: The :class:`~chesssnake.engine.move.Move` that was played.
+        :rtype: Move
         :raises ChessError.InvalidNotationError: If the move is not in standard chess notation.
         :raises ChessError.GameOverError: If the game is over (i.e., the game has ended).
         :raises ChessError.MoveIntoCheckError: If the move puts the player in check.
@@ -125,14 +161,18 @@ class Game:
             raise ChessError.GameOverError()
 
         m = self.board.move(move, self.turn)
+        self.last_move = m
         self.turn = self.turn.opponent  # Changes whose turn it is
+        return m
 
-        if img or save:
-            image = render_board(self.board, self.wname, self.bname, m)
-            if save:
-                image.save(save)
-            return image
-        return None
+    def render(self):
+        """
+        Render the current board to an image (both orientations, last move highlighted).
+
+        :return: A `PIL.Image` of the board.
+        :rtype: PIL.Image
+        """
+        return render_board(self.board, self.wname, self.bname, self.last_move)
 
     def draw_offer(self, player_id: int):
         """
@@ -214,4 +254,4 @@ class Game:
         :param image_fp: The file path where the board image will be saved.
         :type image_fp: str
         """
-        render_board(self.board, self.wname, self.bname).save(image_fp)
+        self.render().save(image_fp)

--- a/src/chesssnake/remote/client.py
+++ b/src/chesssnake/remote/client.py
@@ -6,9 +6,19 @@ be injected (the test-suite passes a Starlette ``TestClient``, which is request
 compatible), so the same client code drives both a real server and an in-process
 app. Non-2xx responses are translated back into the shared ``GameError`` types so
 callers see the same exceptions they would from a local database.
+
+All routes are served under the versioned ``/v1`` prefix. If the server is
+configured with an API key, pass ``api_key=`` and it is sent as ``X-API-Key``.
 """
 
 from ..db import errors
+from ..dto import GameState
+
+# All endpoints live under this version prefix.
+API_PREFIX = "/v1"
+
+# Header carrying the optional API key.
+API_KEY_HEADER = "X-API-Key"
 
 # Error-type name (sent by the server) -> exception class to raise. Types with
 # custom constructors (SQLIdError, SQLAuthError) fall back to their SQLError base,
@@ -25,8 +35,9 @@ _ERROR_TYPES = {
 class ApiClient:
     """Talks to a chesssnake api-endpoint over REST."""
 
-    def __init__(self, base_url, session=None):
+    def __init__(self, base_url, session=None, api_key=None):
         self.base_url = base_url.rstrip("/") if base_url else ""
+        self.api_key = api_key
         if session is None:
             try:
                 import requests
@@ -41,7 +52,10 @@ class ApiClient:
     # --- transport ---------------------------------------------------------
 
     def _request(self, method, path, *, params=None, json=None):
-        resp = self._session.request(method, f"{self.base_url}{path}", params=params, json=json)
+        headers = {API_KEY_HEADER: self.api_key} if self.api_key else None
+        resp = self._session.request(
+            method, f"{self.base_url}{API_PREFIX}{path}", params=params, json=json, headers=headers
+        )
         if resp.status_code >= 400:
             self._raise(resp)
         if resp.content:
@@ -62,8 +76,8 @@ class ApiClient:
 
     # --- games -------------------------------------------------------------
 
-    def get_or_create_game(self, group_id, white_id, black_id, white_name="", black_name=""):
-        return self._request(
+    def get_or_create_game(self, group_id, white_id, black_id, white_name="", black_name="") -> GameState:
+        data = self._request(
             "POST",
             "/games",
             json={
@@ -74,9 +88,10 @@ class ApiClient:
                 "black_name": black_name,
             },
         )
+        return GameState(**data)
 
-    def update_game(self, group_id, white_id, black_id, state):
-        return self._request("PUT", f"/games/{group_id}/{white_id}/{black_id}", json=state)
+    def update_game(self, group_id, white_id, black_id, state: GameState):
+        return self._request("PUT", f"/games/{group_id}/{white_id}/{black_id}", json=state.to_dict())
 
     def update_draw(self, group_id, white_id, black_id, draw, status):
         return self._request(

--- a/src/chesssnake/remote/game.py
+++ b/src/chesssnake/remote/game.py
@@ -1,21 +1,29 @@
 """
-Remote-capable ``Game``.
+Remote-capable ``Game`` and challenge helpers.
 
-By default this is exactly the in-memory engine game (no network, no extra
-dependencies). Pass ``remote=True`` (with an ``api_url`` or the
-``CHESSSNAKE_API_URL`` environment variable) to load/persist the game through a
-``chesssnake api-endpoint`` REST server: the chess engine still runs locally and
-only serialized state crosses the wire, so many clients can share one database.
+Build games with the factory methods:
+
+- ``Game.local(white_name, black_name)`` — a pure in-memory game (no network, no
+  extra dependencies), identical to the raw engine.
+- ``Game.remote(white_id, black_id, group_id=..., api_url=...)`` — load-or-create
+  and persist the game through a ``chesssnake api-endpoint`` REST server. The chess
+  engine still runs locally; only serialized state crosses the wire, so many
+  clients can share one database.
+
+Remote games default to ``auto_sync=True`` (every move/draw is pushed to the
+server). They are also context managers that sync on exit, so state is never
+silently dropped even with ``auto_sync=False``.
 """
 
 import os
 
+from ..dto import GameState
 from ..engine import Board, Square
 from ..engine.enums import GameStatus
 from ..engine.game import Game as BaseGame
 
 
-def _make_client(api_url=None, client=None):
+def _make_client(api_url=None, client=None, api_key=None):
     """Build (or accept an injected) ApiClient for remote operations."""
     if client is not None:
         return client
@@ -24,89 +32,124 @@ def _make_client(api_url=None, client=None):
     url = api_url or os.getenv("CHESSSNAKE_API_URL")
     if not url:
         raise ValueError("A remote game requires an api_url argument or the CHESSSNAKE_API_URL environment variable.")
-    return ApiClient(url)
+    return ApiClient(url, api_key=api_key)
 
 
 class Game(BaseGame):
     """
-    A chess game that optionally persists to a chesssnake api-endpoint.
+    A chess game that is local by default and remote when built via :meth:`remote`.
 
-    :param remote: If True, load-or-create and (optionally) sync this game via the API.
-    :param auto_sync: If True, push state to the API after every move / draw action
-        (implies ``remote=True``).
-    :param api_url: Base URL of the api-endpoint. Falls back to ``CHESSSNAKE_API_URL``.
+    Construct with the factory methods rather than calling ``Game(...)`` directly:
+    :meth:`local` for an in-memory game, :meth:`remote` for a persisted one.
     """
 
-    def __init__(
-        self,
-        white_id=0,
-        black_id=1,
-        group_id=0,
-        white_name="",
-        black_name="",
-        remote=False,
-        auto_sync=False,
-        api_url=None,
-        _client=None,
-    ):
-        self.remote = remote or auto_sync
-        self.auto_sync = auto_sync
-        self._client = None
+    def __init__(self, *args, client=None, auto_sync=False, **kwargs):
+        # Low-level constructor. Prefer Game.local() / Game.remote().
+        self._client = client
+        self.auto_sync = bool(auto_sync and client is not None)
+        super().__init__(*args, **kwargs)
 
-        if self.remote:
-            self._client = _make_client(api_url, _client)
-            state = self._client.get_or_create_game(group_id, white_id, black_id, white_name, black_name)
-            super().__init__(
-                white_id,
-                black_id,
-                group_id,
-                white_name=state["wname"] if state["wname"] is not None else white_name,
-                black_name=state["bname"] if state["bname"] is not None else black_name,
-                board=self._board_from_state(state),
-                turn=state["turn"],
-                draw=state["draw"],
-            )
-        else:
-            super().__init__(white_id, black_id, group_id, white_name, black_name)
+    # --- factories ---------------------------------------------------------
+
+    @classmethod
+    def local(cls, white_name: str = "", black_name: str = "") -> "Game":
+        """Create a purely local, in-memory game (no server, no persistence)."""
+        return cls(white_name=white_name, black_name=black_name)
+
+    @classmethod
+    def remote(
+        cls,
+        white_id: int,
+        black_id: int,
+        group_id: int = 0,
+        *,
+        white_name: str = "",
+        black_name: str = "",
+        api_url: str | None = None,
+        api_key: str | None = None,
+        client=None,
+        auto_sync: bool = True,
+    ) -> "Game":
+        """
+        Load-or-create a persisted game via a chesssnake api-endpoint.
+
+        Games are keyed by ``(group_id, white_id, black_id)``. If a matching game
+        exists it is loaded; otherwise a new one is created.
+
+        :param api_url: Base URL of the api-endpoint (falls back to ``CHESSSNAKE_API_URL``).
+        :param api_key: Optional API key sent with every request.
+        :param client: An injected ``ApiClient`` (mainly for testing).
+        :param auto_sync: Push state to the server after every move/draw (default ``True``).
+        """
+        client = _make_client(api_url, client, api_key)
+        state = client.get_or_create_game(group_id, white_id, black_id, white_name, black_name)
+        return cls(
+            client=client,
+            auto_sync=auto_sync,
+            white_id=white_id,
+            black_id=black_id,
+            group_id=group_id,
+            white_name=state.wname if state.wname is not None else white_name,
+            black_name=state.bname if state.bname is not None else black_name,
+            board=cls._board_from_state(state),
+            turn=state.turn,
+            draw=state.draw,
+        )
+
+    @property
+    def is_remote(self) -> bool:
+        """Whether this game is backed by a remote api-endpoint."""
+        return self._client is not None
+
+    # --- context manager (syncs on exit) -----------------------------------
+
+    def __enter__(self) -> "Game":
+        return self
+
+    def __exit__(self, *exc):
+        # Push the latest state on a clean exit so a forgotten sync() can't drop moves.
+        if exc[0] is None:
+            self.sync()
+        return False
 
     # --- state (de)serialization ------------------------------------------
 
     @staticmethod
-    def _board_from_state(state):
-        if state["pawnmove"] is not None:
-            i, j = Board.get_coords(state["pawnmove"])
+    def _board_from_state(state: GameState) -> Board:
+        if state.pawnmove is not None:
+            i, j = Board.get_coords(state.pawnmove)
             pawnmove = Square(i, j)
         else:
             pawnmove = None
         board = Board(
-            board=Board.assemble_board(state["board"], state["moved"]),
+            board=Board.assemble_board(state.board, state.moved),
             two_moveP=pawnmove,
         )
-        board.status = GameStatus(int(state["status"]))
+        board.status = GameStatus(int(state.status))
         return board
 
-    def _state_payload(self):
+    def _state_payload(self) -> GameState:
         boardstring, moved = Board.disassemble_board(self.board)
-        return {
-            "board": boardstring,
-            "turn": int(self.turn),
-            "pawnmove": self.board.two_moveP.c_notation if self.board.two_moveP else None,
-            "draw": int(self.draw) if self.draw is not None else None,
-            "moved": moved,
-            "status": int(self.board.status),
-            "wname": self.wname,
-            "bname": self.bname,
-        }
+        return GameState(
+            board=boardstring,
+            turn=int(self.turn),
+            moved=moved,
+            status=int(self.board.status),
+            pawnmove=self.board.two_moveP.c_notation if self.board.two_moveP else None,
+            draw=int(self.draw) if self.draw is not None else None,
+            wname=self.wname,
+            bname=self.bname,
+        )
 
     # --- persistence -------------------------------------------------------
 
     def sync(self):
-        """Push the current full game state to the API (no-op for local games)."""
-        if self.remote:
+        """Push the current full game state to the api-endpoint (no-op for local games)."""
+        if self.is_remote:
             self._client.update_game(self.gid, self.wid, self.bid, self._state_payload())
 
-    def move(self, move, img=False, save=None):
-        result = super().move(move, img=img, save=save)
+    def move(self, move):
+        result = super().move(move)
         if self.auto_sync:
             self.sync()
         return result
@@ -132,27 +175,26 @@ class Game(BaseGame):
 
     def end(self):
         """If the game is over, delete it from the remote database. Returns True if ended."""
-        if self.board.status != GameStatus.IN_PLAY:
-            if self.remote:
+        if self.is_over:
+            if self.is_remote:
                 self._client.delete_game(self.gid, self.wid, self.bid)
             return True
         return False
 
 
-class Challenge:
-    """Client wrapper for the challenge endpoints of a chesssnake api-endpoint."""
+# --- challenge helpers (module-level functions) ----------------------------
 
-    @staticmethod
-    def challenge(challenger, opponent, gid=0, api_url=None, _client=None):
-        """Issue or accept a challenge. Returns True if an existing challenge was accepted."""
-        return _make_client(api_url, _client).challenge(challenger, opponent, gid)
 
-    @staticmethod
-    def exists(player1, player2, gid=0, api_url=None, _client=None):
-        """Return the pending challenge between two players, or None."""
-        return _make_client(api_url, _client).challenge_exists(player1, player2, gid)
+def challenge(challenger, opponent, group_id=0, *, api_url=None, api_key=None, client=None):
+    """Issue or accept a challenge. Returns ``True`` if an existing challenge was accepted."""
+    return _make_client(api_url, client, api_key).challenge(challenger, opponent, group_id)
 
-    @staticmethod
-    def delete(challenger, challenged, gid=0, api_url=None, _client=None):
-        """Delete a pending challenge."""
-        _make_client(api_url, _client).delete_challenge(challenger, challenged, gid)
+
+def challenge_exists(player1, player2, group_id=0, *, api_url=None, api_key=None, client=None):
+    """Return the pending challenge between two players, or ``None``."""
+    return _make_client(api_url, client, api_key).challenge_exists(player1, player2, group_id)
+
+
+def delete_challenge(challenger, challenged, group_id=0, *, api_url=None, api_key=None, client=None):
+    """Delete a pending challenge."""
+    _make_client(api_url, client, api_key).delete_challenge(challenger, challenged, group_id)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,5 +1,7 @@
 """Integration tests for the FastAPI api-endpoint hitting a real Postgres."""
 
+import os
+
 import pytest
 
 from chesssnake.db import INITIAL_BOARD
@@ -15,19 +17,19 @@ def test_health(api_client):
 
 def test_create_game_is_idempotent(api_client):
     body = {"group_id": 10, "white_id": 1, "black_id": 2, "white_name": "Bob", "black_name": "Phil"}
-    first = api_client.post("/games", json=body).json()
+    first = api_client.post("/v1/games", json=body).json()
     assert first["board"] == INITIAL_BOARD
     assert first["turn"] == 0
     assert first["draw"] is None
     assert first["wname"] == "Bob"
 
     # Requesting the same game again returns the existing row, not a new one.
-    second = api_client.post("/games", json=body).json()
+    second = api_client.post("/v1/games", json=body).json()
     assert second == first
 
 
 def test_update_and_reload_game(api_client):
-    api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
+    api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
     state = {
         "board": "updated-board-string",
         "turn": 1,
@@ -38,69 +40,115 @@ def test_update_and_reload_game(api_client):
         "wname": "W",
         "bname": "B",
     }
-    r = api_client.put("/games/10/1/2", json=state)
+    r = api_client.put("/v1/games/10/1/2", json=state)
     assert r.status_code == 200
 
-    reloaded = api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()
+    reloaded = api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()
     assert reloaded["board"] == "updated-board-string"
     assert reloaded["turn"] == 1
     assert reloaded["pawnmove"] == "e4"
 
 
 def test_draw_patch_and_clear(api_client):
-    api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
+    api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
 
-    api_client.patch("/games/10/1/2/draw", json={"draw": 0, "status": 0})
-    assert api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()["draw"] == 0
+    api_client.patch("/v1/games/10/1/2/draw", json={"draw": 0, "status": 0})
+    assert api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()["draw"] == 0
 
-    api_client.delete("/games/10/1/2/draw")
-    assert api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()["draw"] is None
+    api_client.delete("/v1/games/10/1/2/draw")
+    assert api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()["draw"] is None
 
 
 def test_delete_game(api_client):
-    api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
-    api_client.patch("/games/10/1/2/draw", json={"draw": 1, "status": 0})
+    api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
+    api_client.patch("/v1/games/10/1/2/draw", json={"draw": 1, "status": 0})
 
-    assert api_client.delete("/games/10/1/2").status_code == 200
+    assert api_client.delete("/v1/games/10/1/2").status_code == 200
 
     # Recreated fresh after deletion (draw back to None).
-    fresh = api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()
+    fresh = api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2}).json()
     assert fresh["draw"] is None
 
 
 def test_current_games_and_exists(api_client):
-    api_client.post("/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
+    api_client.post("/v1/games", json={"group_id": 10, "white_id": 1, "black_id": 2})
 
-    opponents = api_client.get("/games", params={"player_id": 1, "group_id": 10}).json()["opponents"]
+    opponents = api_client.get("/v1/games", params={"player_id": 1, "group_id": 10}).json()["opponents"]
     assert opponents == [2]
 
-    game = api_client.get("/games/10/exists", params={"player1": 2, "player2": 1}).json()["game"]
+    game = api_client.get("/v1/games/10/exists", params={"player1": 2, "player2": 1}).json()["game"]
     assert game == {"white_id": 1, "black_id": 2}
 
-    missing = api_client.get("/games/10/exists", params={"player1": 7, "player2": 8}).json()["game"]
+    missing = api_client.get("/v1/games/10/exists", params={"player1": 7, "player2": 8}).json()["game"]
     assert missing is None
 
 
 def test_challenge_lifecycle(api_client):
-    first = api_client.post("/challenges", json={"group_id": 10, "challenger": 100, "challenged": 200})
+    first = api_client.post("/v1/challenges", json={"group_id": 10, "challenger": 100, "challenged": 200})
     assert first.json()["accepted"] is False
     assert (
-        api_client.get("/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"] is not None
+        api_client.get("/v1/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"]
+        is not None
     )
 
-    accept = api_client.post("/challenges", json={"group_id": 10, "challenger": 200, "challenged": 100})
+    accept = api_client.post("/v1/challenges", json={"group_id": 10, "challenger": 200, "challenged": 100})
     assert accept.json()["accepted"] is True
-    assert api_client.get("/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"] is None
+    assert (
+        api_client.get("/v1/challenges/10/exists", params={"player1": 100, "player2": 200}).json()["challenge"] is None
+    )
 
 
 def test_self_challenge_conflicts(api_client):
-    resp = api_client.post("/challenges", json={"group_id": 10, "challenger": 5, "challenged": 5})
+    resp = api_client.post("/v1/challenges", json={"group_id": 10, "challenger": 5, "challenged": 5})
     assert resp.status_code == 409
     assert resp.json()["error_type"] == "ChallengeError"
 
 
 def test_invalid_id_returns_422(api_client):
     # Beyond PostgreSQL BIGINT range -> SQLIdError -> 422.
-    resp = api_client.post("/games", json={"group_id": 0, "white_id": 10**19, "black_id": 2})
+    resp = api_client.post("/v1/games", json={"group_id": 0, "white_id": 10**19, "black_id": 2})
     assert resp.status_code == 422
     assert resp.json()["error_type"] == "SQLIdError"
+
+
+def test_health_is_unversioned_and_open(api_client):
+    # /health stays at the root (no /v1) and never requires auth.
+    assert api_client.get("/health").status_code == 200
+    assert api_client.get("/v1/games", params={"player_id": 1, "group_id": 10}).status_code == 200
+
+
+def test_api_key_enforced_when_configured(api_client):
+    # When CHESSSNAKE_API_KEY is set, /v1 routes require a matching X-API-Key.
+    os.environ["CHESSSNAKE_API_KEY"] = "s3cret"
+    try:
+        # health stays open regardless
+        assert api_client.get("/health").status_code == 200
+
+        # missing / wrong key -> 401
+        assert api_client.get("/v1/games", params={"player_id": 1, "group_id": 10}).status_code == 401
+        assert (
+            api_client.get(
+                "/v1/games", params={"player_id": 1, "group_id": 10}, headers={"X-API-Key": "wrong"}
+            ).status_code
+            == 401
+        )
+
+        # correct key -> allowed
+        ok = api_client.get("/v1/games", params={"player_id": 1, "group_id": 10}, headers={"X-API-Key": "s3cret"})
+        assert ok.status_code == 200
+    finally:
+        del os.environ["CHESSSNAKE_API_KEY"]
+
+
+def test_client_sends_api_key(api_client):
+    # An ApiClient configured with an api_key authenticates against a keyed server.
+    from chesssnake.remote.client import ApiClient
+
+    os.environ["CHESSSNAKE_API_KEY"] = "s3cret"
+    try:
+        keyed = ApiClient("", session=api_client, api_key="s3cret")
+        # get_or_create goes through the authenticated /v1 route without raising
+        state = keyed.get_or_create_game(10, 1, 2, "A", "B")
+        assert state.board == INITIAL_BOARD
+    finally:
+        del os.environ["CHESSSNAKE_API_KEY"]

--- a/tests/integration/test_remote_game.py
+++ b/tests/integration/test_remote_game.py
@@ -7,15 +7,15 @@ The client's ApiClient is wired to an in-process TestClient (see conftest's
 
 import pytest
 
+from chesssnake import Color
 from chesssnake.db import errors as GameError
-from chesssnake.remote.game import Challenge, Game
+from chesssnake.remote.game import Game, challenge, challenge_exists
 
 pytestmark = pytest.mark.integration
 
 
 def make_game(remote_client, **kwargs):
-    kwargs.setdefault("remote", True)
-    return Game(_client=remote_client, **kwargs)
+    return Game.remote(client=remote_client, **kwargs)
 
 
 def piece_at(board, c_notation):
@@ -26,31 +26,42 @@ def piece_at(board, c_notation):
 
 
 def test_move_syncs_and_reloads(remote_client):
-    g = make_game(remote_client, white_id=1, black_id=2, group_id=10, white_name="Bob", black_name="Phil")
+    g = make_game(
+        remote_client, white_id=1, black_id=2, group_id=10, white_name="Bob", black_name="Phil", auto_sync=False
+    )
     g.move("e4")
     g.move("e5")
     g.move("Nc3")
-    g.sync()
+    g.sync()  # explicit sync (auto_sync disabled)
 
     reloaded = make_game(remote_client, white_id=1, black_id=2, group_id=10)
     assert str(reloaded) == str(g)
-    assert reloaded.turn == g.turn == 1
+    assert reloaded.to_move == g.to_move == Color.BLACK
     assert reloaded.wname == "Bob"
     assert reloaded.bname == "Phil"
 
 
 def test_auto_sync_persists_each_move(remote_client):
-    g = make_game(remote_client, white_id=3, black_id=4, group_id=10, auto_sync=True)
+    g = make_game(remote_client, white_id=3, black_id=4, group_id=10)  # auto_sync defaults True
     g.move("e4")
 
     reloaded = make_game(remote_client, white_id=3, black_id=4, group_id=10)
     p = piece_at(reloaded.board, "e4")
     assert p is not None and p.piecetype.value == "P"
-    assert reloaded.turn == 1
+    assert reloaded.to_move == Color.BLACK
+
+
+def test_context_manager_syncs_on_exit(remote_client):
+    with make_game(remote_client, white_id=13, black_id=14, group_id=10, auto_sync=False) as g:
+        g.move("d4")  # not synced yet (auto_sync off)
+
+    # exiting the context should have pushed the state
+    reloaded = make_game(remote_client, white_id=13, black_id=14, group_id=10)
+    assert piece_at(reloaded.board, "d4") is not None
 
 
 def test_en_passant_target_round_trips(remote_client):
-    g = make_game(remote_client, white_id=5, black_id=6, group_id=10, auto_sync=True)
+    g = make_game(remote_client, white_id=5, black_id=6, group_id=10)
     g.move("e4")  # double pawn push sets the en-passant target
 
     reloaded = make_game(remote_client, white_id=5, black_id=6, group_id=10)
@@ -59,28 +70,28 @@ def test_en_passant_target_round_trips(remote_client):
 
 
 def test_draw_offer_persists(remote_client):
-    g = make_game(remote_client, white_id=7, black_id=8, group_id=10, auto_sync=True)
+    g = make_game(remote_client, white_id=7, black_id=8, group_id=10)
     g.draw_offer(7)
 
     reloaded = make_game(remote_client, white_id=7, black_id=8, group_id=10)
-    assert reloaded.draw == 0
+    assert reloaded.draw_offered_by == Color.WHITE
 
 
 def test_new_remote_game_starts_fresh(remote_client):
     g = make_game(remote_client, white_id=11, black_id=12, group_id=10)
-    assert g.turn == 0
-    assert g.draw is None
-    assert g.board.status == 0
+    assert g.to_move == Color.WHITE
+    assert g.draw_offered_by is None
+    assert g.is_over is False
 
 
 def test_challenge_lifecycle(remote_client):
-    assert Challenge.challenge(100, 200, gid=10, _client=remote_client) is False
-    assert Challenge.exists(100, 200, gid=10, _client=remote_client) is not None
+    assert challenge(100, 200, group_id=10, client=remote_client) is False
+    assert challenge_exists(100, 200, group_id=10, client=remote_client) is not None
 
-    assert Challenge.challenge(200, 100, gid=10, _client=remote_client) is True
-    assert Challenge.exists(100, 200, gid=10, _client=remote_client) is None
+    assert challenge(200, 100, group_id=10, client=remote_client) is True
+    assert challenge_exists(100, 200, group_id=10, client=remote_client) is None
 
 
 def test_self_challenge_raises(remote_client):
     with pytest.raises(GameError.ChallengeError):
-        Challenge.challenge(300, 300, gid=10, _client=remote_client)
+        challenge(300, 300, group_id=10, client=remote_client)

--- a/tests/unit/test_game_flow.py
+++ b/tests/unit/test_game_flow.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from chesssnake import Color, GameStatus
 from chesssnake.engine import Game
 from chesssnake.engine import errors as ChessError
 
@@ -11,6 +12,40 @@ def test_new_game_defaults():
     assert g.turn == 0  # white to move
     assert g.draw is None
     assert g.board.status == 0  # in play
+
+
+def test_accessors_ongoing_game():
+    g = Game(white_name="A", black_name="B")
+    assert g.to_move == Color.WHITE
+    assert g.is_over is False
+    assert g.result == GameStatus.IN_PLAY
+    assert g.winner is None
+    assert g.draw_offered_by is None
+    g.move("e4")
+    assert g.to_move == Color.BLACK
+
+
+def test_accessors_report_checkmate_winner():
+    g = Game()
+    for m in ["f3", "e5", "g4", "Qh4"]:  # fool's mate — black (Qh4#) wins
+        g.move(m)
+    assert g.is_over is True
+    assert g.result == GameStatus.CHECKMATE
+    assert g.winner == Color.BLACK
+
+
+def test_move_returns_the_move_played():
+    g = Game()
+    m = g.move("e4")
+    assert m is g.last_move
+    assert m.to.c_notation == "e4"
+
+
+def test_render_returns_an_image():
+    g = Game(white_name="A", black_name="B")
+    g.move("e4")
+    img = g.render()
+    assert img.size == (1190, 644)
 
 
 def test_move_alternates_turn():
@@ -48,8 +83,11 @@ def test_draw_offer_and_accept_ends_in_draw():
     g = Game(white_id=10, black_id=20)
     g.draw_offer(10)  # white (to move) offers
     assert g.draw == 0
+    assert g.draw_offered_by == Color.WHITE
     g.draw_offer(20)  # black offering back accepts the draw
     assert g.board.status == 2  # draw / stalemate status
+    assert g.result == GameStatus.DRAW
+    assert g.winner is None
 
 
 def test_double_draw_offer_raises():


### PR DESCRIPTION
Implements **Phase 3** — the `[BREAK]` public-surface redesign (pre-release, no back-compat shims). Completes all 7 items. **93 tests pass, ruff + mypy clean, coverage ~82%, `uv build` valid.**

## Changes

**Intention-revealing accessors** on `Game` (users never touch internal ints): `is_over`, `result` (`GameStatus`), `winner` (`Color | None`), `to_move` (`Color`), `draw_offered_by` (`Color | None`). `chesssnake` now also exports `Color` / `GameStatus` / `PieceType`.

**State vs. rendering separated**: `move()` returns the `Move` played; rendering is `game.render()` / `game.save(path)`. Dropped `move()`'s `img=`/`save=` params — the board tracks `last_move`, so `render()`/`save()` still highlight the last move.

**Factory methods** replace the flag-laden constructor:
- `Game.local(white_name, black_name)` — in-memory game
- `Game.remote(white_id, black_id, group_id=0, *, api_url, api_key, client, auto_sync=True)`

Removes the surprising id defaults and the private `_client` seam from the public signature.

**`Challenge` class → module-level functions** `challenge` / `challenge_exists` / `delete_challenge` (exported from `chesssnake`).

**Shared wire payload**: `chesssnake/dto.py`'s `GameState` — a stdlib dataclass (so the client needs no pydantic) used by both `remote/client.py` and `api/server.py`. Replaces the shape that was previously defined in three places.

**Harder to misuse remote persistence**: `Game.remote()` defaults `auto_sync=True`, **and** the remote game is a context manager that `sync()`s on clean exit (a forgotten `sync()` can't silently drop moves).

**Versioned + authenticated HTTP API**: all game/challenge routes moved under a `/v1` prefix (the client prepends it automatically); optional API-key auth via `CHESSSNAKE_API_KEY` on the server + `api_key=` / `X-API-Key` on the client. `/health` stays open and unversioned for probes.

## Tests
Added: accessor tests (incl. checkmate `winner`), `move()`-returns-`Move`, `render()`, remote factory + context-manager sync, challenge functions, `/v1` prefix, and API-key enforcement (missing/wrong → 401, correct → 200; client sends the header). Verified the local path still imports **zero** heavy deps.

## Docs
`README.md`, `CLAUDE.md`, and `examples/example.py` updated to the new API.

---

This completes **all four refactor phases (0–3)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)